### PR TITLE
fix: update repo references for org transfer to kikplate (#28)

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Update Helm repository index
         run: |
           cd gh-pages/charts
-          helm repo index . --url https://moeidheidari.github.io/kikplate/charts
+          helm repo index . --url https://kikplate.github.io/kikplate/charts
           cp index.yaml ../index.yaml
 
       - name: Commit and push to gh-pages

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kikplate)](https://artifacthub.io/packages/search?repo=kikplate)
-  [![GitHub stars](https://img.shields.io/github/stars/moeidheidari/kikplate?style=social)](https://github.com/moeidheidari/kikplate)
+  [![GitHub stars](https://img.shields.io/github/stars/kikplate/kikplate?style=social)](https://github.com/kikplate/kikplate)
   
   
 # Kikplate

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,7 +6,7 @@ The Kikplate CLI (`kikplate`) is a standalone Go binary that lets you browse, su
 
 ### From a Release (Recommended)
 
-Download the binary for your platform from the [GitHub Releases](https://github.com/MoeidHeidari/kikplate/releases) page.
+Download the binary for your platform from the [GitHub Releases](https://github.com/kikplate/kikplate/releases) page.
 
 ```
 tar -xzf kikplate-<version>-linux-amd64.tar.gz
@@ -18,7 +18,7 @@ Supported platforms: Linux amd64, Linux arm64, macOS amd64, macOS arm64.
 ### From Source
 
 ```
-git clone https://github.com/MoeidHeidari/kikplate.git
+git clone https://github.com/kikplate/kikplate.git
 cd kikplate/cli
 go build -o kikplate .
 sudo mv kikplate /usr/local/bin/kikplate

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,7 +179,7 @@ UI customization applied to the web frontend. These values are served from `GET 
 customization:
   logo: /kikplate-logo-on-dark.svg
   banner_title: "The Home of your starter boilerplates"
-  badge_request_url: "https://github.com/MoeidHeidari/kikplate/issues/new?template=badge-request.yml"
+  badge_request_url: "https://github.com/kikplate/kikplate/issues/new?template=badge-request.yml"
   social_media:
     - type: github
       link: "https://github.com/yourorg"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ The following tools must be installed before you begin:
 ## Clone the Repository
 
 ```
-git clone https://github.com/MoeidHeidari/kikplate.git
+git clone https://github.com/kikplate/kikplate.git
 cd kikplate
 ```
 

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -18,7 +18,7 @@ Kikplate provides an official Helm chart that deploys the full stack — API, sy
 The chart is published to GHCR on every release. No repository registration needed:
 
 ```
-helm install kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
+helm install kikplate oci://ghcr.io/kikplate/helm-charts/kikplate \
   --namespace kikplate \
   --create-namespace
 ```
@@ -26,7 +26,7 @@ helm install kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
 With required secrets set at install time:
 
 ```
-helm install kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
+helm install kikplate oci://ghcr.io/kikplate/helm-charts/kikplate \
   --namespace kikplate \
   --create-namespace \
   --set secrets.jwtSecret="$(openssl rand -base64 32)" \
@@ -36,7 +36,7 @@ helm install kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
 ### From the Helm Repository
 
 ```
-helm repo add kikplate https://moeidheidari.github.io/kikplate
+helm repo add kikplate https://kikplate.github.io/kikplate
 helm repo update
 helm install kikplate kikplate/kikplate \
   --namespace kikplate \
@@ -46,7 +46,7 @@ helm install kikplate kikplate/kikplate \
 ## Upgrading
 
 ```
-helm upgrade kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
+helm upgrade kikplate oci://ghcr.io/kikplate/helm-charts/kikplate \
   --namespace kikplate
 ```
 
@@ -96,7 +96,7 @@ Optional namespace override. By default, Helm uses the namespace passed to `helm
 api:
   replicaCount: 1
   image:
-    repository: ghcr.io/moeidheidari/kikplate-api
+    repository: ghcr.io/kikplate/kikplate-api
     tag: main
     pullPolicy: IfNotPresent
   service:
@@ -116,7 +116,7 @@ api:
 sync:
   replicaCount: 1
   image:
-    repository: ghcr.io/moeidheidari/kikplate-api
+    repository: ghcr.io/kikplate/kikplate-api
     tag: main
     pullPolicy: IfNotPresent
   resources:
@@ -136,7 +136,7 @@ The sync worker uses the same image as the API server. The chart sets `args: ["a
 web:
   replicaCount: 1
   image:
-    repository: ghcr.io/moeidheidari/kikplate-web
+    repository: ghcr.io/kikplate/kikplate-web
     tag: main
     pullPolicy: IfNotPresent
   service:
@@ -242,7 +242,7 @@ config:
   customization:
     logo: /kikplate-logo-on-dark.svg
     bannerTitle: "The Home of your starter boilerplates"
-    badgeRequestUrl: "https://github.com/MoeidHeidari/kikplate/issues/new?template=badge-request.yml"
+    badgeRequestUrl: "https://github.com/kikplate/kikplate/issues/new?template=badge-request.yml"
 ```
 
 ## Production Values File Example
@@ -282,7 +282,7 @@ config:
 Install:
 
 ```
-helm install kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
+helm install kikplate oci://ghcr.io/kikplate/helm-charts/kikplate \
   --namespace kikplate \
   --create-namespace \
   -f production-values.yaml \
@@ -302,7 +302,7 @@ kubectl scale deployment -n kikplate -l app.kubernetes.io/component=web --replic
 Or pass updated replicas to `helm upgrade`:
 
 ```
-helm upgrade kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
+helm upgrade kikplate oci://ghcr.io/kikplate/helm-charts/kikplate \
   --namespace kikplate \
   --set api.replicaCount=3 \
   --set web.replicaCount=3
@@ -311,7 +311,7 @@ helm upgrade kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
 ## Viewing Chart Values
 
 ```
-helm show values oci://ghcr.io/moeidheidari/helm-charts/kikplate
+helm show values oci://ghcr.io/kikplate/helm-charts/kikplate
 ```
 
 ## Checking Deployment Status
@@ -327,7 +327,7 @@ kubectl rollout status deployment/kikplate-web -n kikplate
 Show rendered templates without installing:
 
 ```
-helm template kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
+helm template kikplate oci://ghcr.io/kikplate/helm-charts/kikplate \
   --namespace kikplate \
   -f production-values.yaml
 ```

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -23,7 +23,7 @@ Kikplate deploys as four workloads:
 | `web` | Deployment | Next.js frontend |
 | `postgres` | Deployment | PostgreSQL with a PersistentVolumeClaim |
 
-The API and sync worker use the same container image (`ghcr.io/moeidheidari/kikplate-api`) but run different commands. Both mount the same ConfigMap and Secret.
+The API and sync worker use the same container image (`ghcr.io/kikplate/kikplate-api`) but run different commands. Both mount the same ConfigMap and Secret.
 
 ## Resource Overview
 
@@ -211,7 +211,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: ghcr.io/moeidheidari/kikplate-api:v1.2.0
+          image: ghcr.io/kikplate/kikplate-api:v1.2.0
 ```
 
 ## Health Checks
@@ -244,9 +244,9 @@ kubectl logs -n kikplate deploy/api -f
 To deploy a new image tag, update the image in the relevant deployment and apply:
 
 ```
-kubectl set image deployment/api api=ghcr.io/moeidheidari/kikplate-api:v1.3.0 -n kikplate
-kubectl set image deployment/sync sync=ghcr.io/moeidheidari/kikplate-api:v1.3.0 -n kikplate
-kubectl set image deployment/web web=ghcr.io/moeidheidari/kikplate-web:v1.3.0 -n kikplate
+kubectl set image deployment/api api=ghcr.io/kikplate/kikplate-api:v1.3.0 -n kikplate
+kubectl set image deployment/sync sync=ghcr.io/kikplate/kikplate-api:v1.3.0 -n kikplate
+kubectl set image deployment/web web=ghcr.io/kikplate/kikplate-web:v1.3.0 -n kikplate
 ```
 
 Or update your Kustomize overlay and re-apply.

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -9,26 +9,26 @@ keywords:
   - boilerplate
   - starter
   - templates
-home: https://github.com/MoeidHeidari/kikplate
+home: https://github.com/kikplate/kikplate
 sources:
-  - https://github.com/MoeidHeidari/kikplate
+  - https://github.com/kikplate/kikplate
 maintainers:
-  - name: MoeidHeidari
-    url: https://github.com/MoeidHeidari
+  - name: kikplate
+    url: https://github.com/kikplate
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/links: |
     - name: source
-      url: https://github.com/MoeidHeidari/kikplate
+      url: https://github.com/kikplate/kikplate
     - name: support
-      url: https://github.com/MoeidHeidari/kikplate/issues
+      url: https://github.com/kikplate/kikplate/issues
     - name: chart
-      url: https://github.com/MoeidHeidari/kikplate/tree/helm/helm
+      url: https://github.com/kikplate/kikplate/tree/helm/helm
   artifacthub.io/images: |
     - name: kikplate-api
-      image: ghcr.io/moeidheidari/kikplate-api:main
+      image: ghcr.io/kikplate/kikplate-api:main
     - name: kikplate-web
-      image: ghcr.io/moeidheidari/kikplate-web:main
+      image: ghcr.io/kikplate/kikplate-web:main
     - name: postgres
       image: postgres:16
-icon: https://raw.githubusercontent.com/MoeidHeidari/kikplate/main/web/public/kikplate-logo-on-dark.svg
+icon: https://raw.githubusercontent.com/kikplate/kikplate/main/web/public/kikplate-logo-on-dark.svg

--- a/helm/README.md
+++ b/helm/README.md
@@ -13,7 +13,7 @@ Kikplate is a self hosted platform for discovering, sharing, and submitting star
 ## Install
 
 ```bash
-helm install kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
+helm install kikplate oci://ghcr.io/kikplate/helm-charts/kikplate \
   --namespace kikplate \
   --create-namespace
 ```
@@ -21,7 +21,7 @@ helm install kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
 ## Install With Required Secrets
 
 ```bash
-helm install kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
+helm install kikplate oci://ghcr.io/kikplate/helm-charts/kikplate \
   --namespace kikplate \
   --create-namespace \
   --set secrets.jwtSecret="$(openssl rand -base64 32)" \
@@ -31,7 +31,7 @@ helm install kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
 ## Upgrade
 
 ```bash
-helm upgrade kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
+helm upgrade kikplate oci://ghcr.io/kikplate/helm-charts/kikplate \
   --namespace kikplate
 ```
 
@@ -51,7 +51,7 @@ The following table lists the main configurable parameters and their default val
 | `fullnameOverride` | Optional full name override for generated resources | `""` |
 | `namespace` | Optional namespace override. Leave empty to use the Helm release namespace | `""` |
 | `api.replicaCount` | Number of backend replicas | `1` |
-| `api.image.repository` | Backend image repository | `ghcr.io/moeidheidari/kikplate-api` |
+| `api.image.repository` | Backend image repository | `ghcr.io/kikplate/kikplate-api` |
 | `api.image.tag` | Backend image tag | `main` |
 | `api.image.pullPolicy` | Backend image pull policy | `IfNotPresent` |
 | `api.service.port` | Backend service port | `3001` |
@@ -60,11 +60,11 @@ The following table lists the main configurable parameters and their default val
 | `api.resources.limits.cpu` | Backend CPU limit | `500m` |
 | `api.resources.limits.memory` | Backend memory limit | `512Mi` |
 | `sync.replicaCount` | Number of sync worker replicas | `1` |
-| `sync.image.repository` | Sync worker image repository | `ghcr.io/moeidheidari/kikplate-api` |
+| `sync.image.repository` | Sync worker image repository | `ghcr.io/kikplate/kikplate-api` |
 | `sync.image.tag` | Sync worker image tag | `main` |
 | `sync.image.pullPolicy` | Sync worker image pull policy | `IfNotPresent` |
 | `web.replicaCount` | Number of frontend replicas | `1` |
-| `web.image.repository` | Frontend image repository | `ghcr.io/moeidheidari/kikplate-web` |
+| `web.image.repository` | Frontend image repository | `ghcr.io/kikplate/kikplate-web` |
 | `web.image.tag` | Frontend image tag | `main` |
 | `web.image.pullPolicy` | Frontend image pull policy | `IfNotPresent` |
 | `web.service.port` | Frontend service port | `3000` |
@@ -91,7 +91,7 @@ The following table lists the main configurable parameters and their default val
 | `config.sync.batchSize` | Batch size for synchronization jobs | `25` |
 | `config.customization.logo` | Logo path used by the frontend | `/kikplate-logo-on-dark.svg` |
 | `config.customization.bannerTitle` | Main homepage banner title | `The Home of your starter boilerplates` |
-| `config.customization.badgeRequestUrl` | URL used for badge requests | `https://github.com/MoeidHeidari/kikplate/issues/new?template=badge-request.yml` |
+| `config.customization.badgeRequestUrl` | URL used for badge requests | `https://github.com/kikplate/kikplate/issues/new?template=badge-request.yml` |
 | `config.customization.socialMedia` | Social links shown in the UI | `github`, `slack`, `linkedin`, `x` entries |
 | `config.customization.preparedQueries` | Prepared search suggestions shown in the homepage search | See `values.yaml` |
 | `config.sso.providers` | OAuth provider definitions rendered into config | `github`, `google`, `gitlab` |

--- a/helm/index.html
+++ b/helm/index.html
@@ -476,9 +476,9 @@
 
             <div class="nav-links">
                 <a href="#install">Install</a>
-                <a href="https://github.com/MoeidHeidari/kikplate/tree/helm/helm" target="_blank" rel="noopener noreferrer">Chart</a>
+                <a href="https://github.com/kikplate/kikplate/tree/helm/helm" target="_blank" rel="noopener noreferrer">Chart</a>
                 <div class="divider" aria-hidden="true"></div>
-                <a href="https://github.com/MoeidHeidari/kikplate" target="_blank" rel="noopener noreferrer">GitHub</a>
+                <a href="https://github.com/kikplate/kikplate" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
     </nav>
@@ -503,7 +503,7 @@
                         <h2>Quick Install</h2>
                         <button class="copy-button" type="button" data-copy-target="quick-install">Copy</button>
                     </div>
-                    <pre id="quick-install">helm install kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
+                    <pre id="quick-install">helm install kikplate oci://ghcr.io/kikplate/helm-charts/kikplate \
   --namespace kikplate \
   --create-namespace</pre>
                 </div>
@@ -516,13 +516,13 @@
                     <div class="section-row">
                         <h3>1. Inspect available versions</h3>
                         <p>Query the OCI chart directly when you need a specific release.</p>
-                        <code class="inline-code">helm show chart oci://ghcr.io/moeidheidari/helm-charts/kikplate --version 0.1.1</code>
+                        <code class="inline-code">helm show chart oci://ghcr.io/kikplate/helm-charts/kikplate --version 0.1.1</code>
                     </div>
 
                     <div class="section-row">
                         <h3>2. Install with overrides</h3>
                         <p>Pass runtime secrets and install in one command.</p>
-                        <code class="inline-code">helm install kikplate oci://ghcr.io/moeidheidari/helm-charts/kikplate \
+                        <code class="inline-code">helm install kikplate oci://ghcr.io/kikplate/helm-charts/kikplate \
   --namespace kikplate \
   --create-namespace \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
@@ -540,15 +540,15 @@ kubectl port-forward -n kikplate svc/web 3000:3000</code>
                 <div class="section-block meta-grid">
                     <div class="meta-item">
                         <span class="meta-label">OCI</span>
-                        <div class="meta-value">oci://ghcr.io/moeidheidari/helm-charts/kikplate</div>
+                        <div class="meta-value">oci://ghcr.io/kikplate/helm-charts/kikplate</div>
                     </div>
                     <div class="meta-item">
                         <span class="meta-label">Chart Source</span>
-                        <div class="meta-value"><a href="https://github.com/MoeidHeidari/kikplate/tree/helm/helm" target="_blank" rel="noopener noreferrer">View chart files</a></div>
+                        <div class="meta-value"><a href="https://github.com/kikplate/kikplate/tree/helm/helm" target="_blank" rel="noopener noreferrer">View chart files</a></div>
                     </div>
                     <div class="meta-item">
                         <span class="meta-label">Configuration</span>
-                        <div class="meta-value"><a href="https://github.com/MoeidHeidari/kikplate/blob/helm/helm/values.yaml" target="_blank" rel="noopener noreferrer">Review values.yaml</a></div>
+                        <div class="meta-value"><a href="https://github.com/kikplate/kikplate/blob/helm/helm/values.yaml" target="_blank" rel="noopener noreferrer">Review values.yaml</a></div>
                     </div>
                 </div>
             </div>
@@ -564,8 +564,8 @@ kubectl port-forward -n kikplate svc/web 3000:3000</code>
                 </div>
                 <div class="footer-links">
                     <p class="footer-title">Project</p>
-                    <a href="https://github.com/MoeidHeidari/kikplate" target="_blank" rel="noopener noreferrer">Repository</a>
-                    <a href="https://github.com/MoeidHeidari/kikplate/issues" target="_blank" rel="noopener noreferrer">Issues</a>
+                    <a href="https://github.com/kikplate/kikplate" target="_blank" rel="noopener noreferrer">Repository</a>
+                    <a href="https://github.com/kikplate/kikplate/issues" target="_blank" rel="noopener noreferrer">Issues</a>
                 </div>
                 <div class="footer-links">
                     <p class="footer-title">Chart</p>

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -6,20 +6,20 @@ entries:
       created: ""
       description: Kikplate – the home of your starter boilerplates.
       digest: ""
-      home: https://github.com/MoeidHeidari/kikplate
-      icon: https://raw.githubusercontent.com/MoeidHeidari/kikplate/main/web/public/kikplate-logo-on-dark.svg
+      home: https://github.com/kikplate/kikplate
+      icon: https://raw.githubusercontent.com/kikplate/kikplate/main/web/public/kikplate-logo-on-dark.svg
       keywords:
         - kikplate
         - boilerplate
         - starter
         - templates
       maintainers:
-        - name: MoeidHeidari
-          url: https://github.com/MoeidHeidari
+        - name: kikplate
+          url: https://github.com/kikplate
       name: kikplate
       sources:
-        - https://github.com/MoeidHeidari/kikplate
+        - https://github.com/kikplate/kikplate
       urls:
-        - https://moeidheidari.github.io/kikplate/kikplate-0.1.0.tgz
+        - https://kikplate.github.io/kikplate/kikplate-0.1.0.tgz
       version: 0.1.0
 generated: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -13,7 +13,7 @@ namespace: ""
 api:
   replicaCount: 1
   image:
-    repository: ghcr.io/moeidheidari/kikplate-api
+    repository: ghcr.io/kikplate/kikplate-api
     tag: main
     pullPolicy: IfNotPresent
   service:
@@ -38,7 +38,7 @@ api:
 sync:
   replicaCount: 1
   image:
-    repository: ghcr.io/moeidheidari/kikplate-api
+    repository: ghcr.io/kikplate/kikplate-api
     tag: main
     pullPolicy: IfNotPresent
   resources:
@@ -55,7 +55,7 @@ sync:
 web:
   replicaCount: 1
   image:
-    repository: ghcr.io/moeidheidari/kikplate-web
+    repository: ghcr.io/kikplate/kikplate-web
     tag: main
     pullPolicy: IfNotPresent
   service:
@@ -168,7 +168,7 @@ config:
   customization:
     logo: /kikplate-logo-on-dark.svg
     bannerTitle: "The Home of your starter boilerplates"
-    badgeRequestUrl: "https://github.com/MoeidHeidari/kikplate/issues/new?template=badge-request.yml"
+    badgeRequestUrl: "https://github.com/kikplate/kikplate/issues/new?template=badge-request.yml"
     socialMedia:
       - type: github
         link: "https://github.com/kickplate"

--- a/kubernetes/base/api-deployment.yaml
+++ b/kubernetes/base/api-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: ghcr.io/moeidheidari/kikplate-api:latest
+          image: ghcr.io/kikplate/kikplate-api:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3001

--- a/kubernetes/base/app-config-configmap.yaml
+++ b/kubernetes/base/app-config-configmap.yaml
@@ -47,7 +47,7 @@ data:
     customization:
       logo: /kikplate-logo-on-dark.svg
       banner_title: The Home of your starter boilerplates
-      badge_request_url: https://github.com/MoeidHeidari/kikplate/issues/new?template=badge-request.yml
+      badge_request_url: https://github.com/kikplate/kikplate/issues/new?template=badge-request.yml
       social_media:
         - type: github
           link: https://github.com/kickplate

--- a/kubernetes/base/sync-deployment.yaml
+++ b/kubernetes/base/sync-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: sync
-          image: ghcr.io/moeidheidari/kikplate-api:latest
+          image: ghcr.io/kikplate/kikplate-api:latest
           imagePullPolicy: IfNotPresent
           args:
             - app:sync

--- a/kubernetes/base/web-deployment.yaml
+++ b/kubernetes/base/web-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: ghcr.io/moeidheidari/kikplate-web:latest
+          image: ghcr.io/kikplate/kikplate-web:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/kubernetes/overlays/dev/kustomization.yaml
+++ b/kubernetes/overlays/dev/kustomization.yaml
@@ -3,10 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
 images:
-  - name: ghcr.io/moeidheidari/kikplate-api
+  - name: ghcr.io/kikplate/kikplate-api
     newName: kikplate-api
     newTag: dev-local
-  - name: ghcr.io/moeidheidari/kikplate-web
+  - name: ghcr.io/kikplate/kikplate-web
     newName: kikplate-web
     newTag: dev-local-v2
 patches:

--- a/web/src/presentation/components/plates/FeaturedPlates.tsx
+++ b/web/src/presentation/components/plates/FeaturedPlates.tsx
@@ -137,7 +137,7 @@ export function FeaturedPlates() {
             </div>
             <div className="mt-6">
               <Link
-                href="https://github.com/MoeidHeidari/kikplate/tree/main/cli"
+                href="https://github.com/kikplate/kikplate/tree/main/cli"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1.5 border border-border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted"


### PR DESCRIPTION
Replace all MoeidHeidari/kikplate references with kikplate/kikplate across workflows, helm chart, kubernetes manifests, and docs.