### PR TITLE
Pre release

### DIFF
--- a/web/app/(main)/plates/[slug]/page.tsx
+++ b/web/app/(main)/plates/[slug]/page.tsx
@@ -297,14 +297,6 @@ export default async function PlateDetailPage({ params }: Props) {
               ) : null}
             </div>
 
-            {relatedPlates.length > 0 && relatedExploreHref ? (
-              <RelatedPlates
-                plates={relatedPlates}
-                exploreHref={relatedExploreHref}
-                exploreLabel={relatedExploreLabel}
-              />
-            ) : null}
-
             <BadgeShowcase
               allBadges={allBadges}
               plateBadges={plate.badges ?? []}
@@ -334,6 +326,14 @@ export default async function PlateDetailPage({ params }: Props) {
                 )}
               </div>
             )}
+
+            {relatedPlates.length > 0 && relatedExploreHref ? (
+              <RelatedPlates
+                plates={relatedPlates}
+                exploreHref={relatedExploreHref}
+                exploreLabel={relatedExploreLabel}
+              />
+            ) : null}
 
           </aside>
         </div>

--- a/web/components/ui/dropdown-menu.tsx
+++ b/web/components/ui/dropdown-menu.tsx
@@ -41,7 +41,7 @@ function DropdownMenuContent({
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
-          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-none border border-border bg-popover p-1 text-popover-foreground shadow-none duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn("z-50 max-h-(--available-height) min-w-32 w-max max-w-[min(24rem,calc(100vw-2rem))] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-none border border-border bg-popover p-1 text-popover-foreground shadow-none duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
           {...props}
         />
       </MenuPrimitive.Positioner>

--- a/web/src/presentation/components/account/OwnedPlates.tsx
+++ b/web/src/presentation/components/account/OwnedPlates.tsx
@@ -6,8 +6,33 @@ import { usePlates, useRemovePlate, useMovePlateOrganization } from "@/src/prese
 import { useMyOrganizations } from "@/src/presentation/hooks/useOrganizations"
 import { LoadingSpinner } from "@/src/presentation/components/common/LoadingSpinner"
 import { PendingVerification } from "@/src/presentation/components/plates/PendingVerification"
+import { PlateGetBadgeModal } from "@/src/presentation/components/account/PlateGetBadgeModal"
 import { Button } from "@/components/ui/button"
-import { GitBranch, Plus, Trash2, Key, ChevronDown, Copy, Check } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import type { Plate } from "@/src/domain/entities/Plate"
+import {
+  Building2,
+  Code2,
+  Copy,
+  GitBranch,
+  MoreVertical,
+  Plus,
+  Trash2,
+} from "lucide-react"
 import { toast } from "sonner"
 
 export function OwnedPlates({ accountId }: { accountId: string }) {
@@ -25,12 +50,12 @@ export function OwnedPlates({ accountId }: { accountId: string }) {
     targetOrgName: string
   } | null>(null)
   const [moveError, setMoveError] = useState<string | null>(null)
-  const [visibleTokenIds, setVisibleTokenIds] = useState<Set<string>>(new Set())
-  const [tokenCopiedId, setTokenCopiedId] = useState<string | null>(null)
   const [confirmingPlate, setConfirmingPlate] = useState<{ id: string; name: string } | null>(null)
   const [removeError, setRemoveError] = useState<string | null>(null)
   const [confirmNameInput, setConfirmNameInput] = useState("")
   const [moveConfirmNameInput, setMoveConfirmNameInput] = useState("")
+  const [getBadgePlate, setGetBadgePlate] = useState<Plate | null>(null)
+  const [orgDialogPlate, setOrgDialogPlate] = useState<Plate | null>(null)
 
   const canRemove = Boolean(confirmingPlate && confirmNameInput === confirmingPlate.name)
   const canMove = Boolean(confirmingMove && moveConfirmNameInput === confirmingMove.plateName)
@@ -65,6 +90,7 @@ export function OwnedPlates({ accountId }: { accountId: string }) {
       }))
       setConfirmingMove(null)
       setMoveConfirmNameInput("")
+      setOrgDialogPlate((p) => (p?.id === confirmingMove.plateId ? null : p))
     } catch (error) {
       setMoveError(error instanceof Error ? error.message : "Failed to move plate")
     } finally {
@@ -144,14 +170,26 @@ export function OwnedPlates({ accountId }: { accountId: string }) {
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {publishedPlates.map((plate) => (
-            <div key={plate.id} className="rounded-xl border border-border bg-card p-4">
-              <div className="space-y-2">
-                <div className="flex items-start justify-between gap-2">
-                  <Link href={`/plates/${plate.slug}`} className="line-clamp-1 text-sm font-semibold hover:underline">
+            {publishedPlates.map((plate) => {
+              const organizationLabel =
+                plate.organization?.name ??
+                (plate.organization_id
+                  ? organizations.find((o) => o.id === plate.organization_id)?.name
+                  : undefined)
+
+              return (
+            <div key={plate.id} className="group relative rounded-xl border border-border bg-card p-4">
+              <Link
+                href={`/plates/${encodeURIComponent(plate.slug)}`}
+                className="absolute inset-0 z-0 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background"
+                aria-label={`Open plate: ${plate.name}`}
+              />
+              <div className="relative z-10 space-y-2 pointer-events-none">
+                <div className="flex items-start gap-2">
+                  <span className="min-w-0 flex-1 line-clamp-2 text-sm font-semibold leading-snug group-hover:underline">
                     {plate.name}
-                  </Link>
-                  <div className="flex shrink-0 items-center gap-1.5">
+                  </span>
+                  <div className="flex shrink-0 flex-wrap items-center justify-end gap-1">
                     <span className={`inline-flex items-center border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${visibilityBadgeClass(plate.visibility)}`}>
                       {plate.visibility}
                     </span>
@@ -165,6 +203,60 @@ export function OwnedPlates({ accountId }: { accountId: string }) {
                         Unverified
                       </span>
                     )}
+                    <div className="pointer-events-auto">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-none border border-transparent text-muted-foreground outline-none transition-colors hover:border-border hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50">
+                        <MoreVertical className="h-4 w-4" />
+                        <span className="sr-only">Plate actions</span>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          className="cursor-pointer gap-2"
+                          onClick={() => setGetBadgePlate(plate)}
+                        >
+                          <Code2 className="h-4 w-4" />
+                          Get badge
+                        </DropdownMenuItem>
+                        {plate.verification_token ? (
+                          <DropdownMenuItem
+                            className="cursor-pointer gap-2"
+                            onClick={async () => {
+                              try {
+                                await navigator.clipboard.writeText(plate.verification_token!)
+                                toast.success("Verification token copied")
+                              } catch {
+                                toast.error("Could not copy")
+                              }
+                            }}
+                          >
+                            <Copy className="h-4 w-4" />
+                            Copy verification token
+                          </DropdownMenuItem>
+                        ) : null}
+                        <DropdownMenuItem
+                          className="cursor-pointer gap-2"
+                          onClick={() => setOrgDialogPlate(plate)}
+                        >
+                          <Building2 className="h-4 w-4" />
+                          Organization…
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          variant="destructive"
+                          className="cursor-pointer gap-2"
+                          disabled={removePlate.isPending && removingId === plate.id}
+                          onClick={() => {
+                            setConfirmingPlate({ id: plate.id, name: plate.name })
+                            setConfirmNameInput("")
+                            setRemoveError(null)
+                          }}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                          {removePlate.isPending && removingId === plate.id ? "Removing…" : "Remove"}
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                    </div>
                   </div>
                 </div>
                 {plate.description ? (
@@ -191,122 +283,18 @@ export function OwnedPlates({ accountId }: { accountId: string }) {
                 )}
               </div>
 
-              <div className="mt-4 flex items-center justify-between gap-2">
-                <p className="text-[11px] uppercase tracking-wide text-muted-foreground">{plate.category}</p>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setConfirmingPlate({ id: plate.id, name: plate.name })
-                    setConfirmNameInput("")
-                    setRemoveError(null)
-                  }}
-                  disabled={removePlate.isPending && removingId === plate.id}
-                  className="inline-flex items-center gap-1 rounded-md border border-destructive/30 px-2 py-1 text-xs text-destructive transition-colors hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                  {removePlate.isPending && removingId === plate.id ? "Removing..." : "Remove"}
-                </button>
-              </div>
-
-              {plate.verification_token && (
-                <div className="mt-3 border-t border-border pt-3 space-y-2">
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setVisibleTokenIds((prev) => {
-                        const next = new Set(prev)
-                        if (next.has(plate.id)) next.delete(plate.id)
-                        else next.add(plate.id)
-                        return next
-                      })
-                    }
-                    className="flex w-full items-center gap-1.5 text-[11px] uppercase tracking-wide text-muted-foreground transition-colors hover:text-foreground"
-                  >
-                    <Key className="h-3 w-3" />
-                    <span className="flex-1 text-left">Verification token</span>
-                    <ChevronDown
-                      className={`h-3 w-3 transition-transform ${
-                        visibleTokenIds.has(plate.id) ? "rotate-180" : ""
-                      }`}
-                    />
-                  </button>
-                  {visibleTokenIds.has(plate.id) && (
-                    <div className="flex items-center gap-0 border border-border">
-                      <code className="flex-1 truncate bg-muted/20 px-3 py-2 text-[11px] font-mono text-foreground">
-                        {plate.verification_token}
-                      </code>
-                      <button
-                        type="button"
-                        onClick={async () => {
-                          await navigator.clipboard.writeText(plate.verification_token!)
-                          setTokenCopiedId(plate.id)
-                          toast.success("Token copied to clipboard")
-                          setTimeout(() => setTokenCopiedId(null), 2000)
-                        }}
-                        className="border-l border-border px-3 py-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                      >
-                        {tokenCopiedId === plate.id
-                          ? <Check className="h-3.5 w-3.5 text-green-500" />
-                          : <Copy className="h-3.5 w-3.5" />}
-                      </button>
-                    </div>
-                  )}
-                </div>
-              )}
-
-              <div className="mt-3 space-y-2 border-t border-border pt-3">
-                <label className="text-[11px] uppercase tracking-wide text-muted-foreground">Organization</label>
-                <div className="flex items-center gap-2">
-                  <select
-                    value={selectedOrgByPlate[plate.id] ?? (plate.organization_id ?? "")}
-                    onChange={(e) => {
-                      const value = e.target.value
-                      setSelectedOrgByPlate((prev) => ({ ...prev, [plate.id]: value }))
-                    }}
-                    className="h-8 flex-1 border border-input bg-transparent px-2 text-xs outline-none transition-colors focus:border-ring"
-                    disabled={orgsLoading || (movePlateOrganization.isPending && movingId === plate.id)}
-                  >
-                    <option value="">Personal (no organization)</option>
-                    {organizations.map((org) => (
-                      <option key={org.id} value={org.id}>
-                        {org.name}
-                      </option>
-                    ))}
-                  </select>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      const currentOrgId = plate.organization_id ?? ""
-                      const selectedOrgId = selectedOrgByPlate[plate.id] ?? currentOrgId
-
-                      if (selectedOrgId === currentOrgId) {
-                        setMoveError("Select a different organization before moving this plate")
-                        return
-                      }
-
-                      const targetOrgName = selectedOrgId === ""
-                        ? "Personal (no organization)"
-                        : (organizations.find((org) => org.id === selectedOrgId)?.name ?? "selected organization")
-
-                      setMoveError(null)
-                      setMoveConfirmNameInput("")
-                      setConfirmingMove({
-                        plateId: plate.id,
-                        plateName: plate.name,
-                        targetOrgId: selectedOrgId,
-                        targetOrgName,
-                      })
-                    }}
-                    disabled={orgsLoading || (movePlateOrganization.isPending && movingId === plate.id)}
-                  >
-                    {movePlateOrganization.isPending && movingId === plate.id ? "Moving..." : "Move"}
-                  </Button>
-                </div>
-              </div>
+              <p className="relative z-10 mt-4 text-[11px] uppercase tracking-wide text-muted-foreground pointer-events-none">
+                {plate.category}
+              </p>
+              {organizationLabel ? (
+                <p className="relative z-10 mt-1.5 flex items-center gap-1.5 text-xs text-muted-foreground pointer-events-none">
+                  <Building2 className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+                  <span className="min-w-0 truncate font-medium text-foreground/90">{organizationLabel}</span>
+                </p>
+              ) : null}
             </div>
-          ))}
+              )
+            })}
         </div>
       )}
       </div>
@@ -360,6 +348,81 @@ export function OwnedPlates({ accountId }: { accountId: string }) {
           </div>
         </div>
       )}
+
+      <Dialog open={Boolean(orgDialogPlate)} onOpenChange={(open) => { if (!open) setOrgDialogPlate(null) }}>
+        <DialogContent className="sm:max-w-md">
+          {orgDialogPlate ? (
+            <>
+              <DialogHeader>
+                <DialogTitle>Organization</DialogTitle>
+                <DialogDescription>
+                  Move &quot;{orgDialogPlate.name}&quot; between your personal namespace and an organization you manage.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-2 py-1">
+                <label htmlFor={`org-select-${orgDialogPlate.id}`} className="text-xs text-muted-foreground">
+                  Organization
+                </label>
+                <select
+                  id={`org-select-${orgDialogPlate.id}`}
+                  value={selectedOrgByPlate[orgDialogPlate.id] ?? (orgDialogPlate.organization_id ?? "")}
+                  onChange={(e) => {
+                    const value = e.target.value
+                    setSelectedOrgByPlate((prev) => ({ ...prev, [orgDialogPlate.id]: value }))
+                  }}
+                  className="h-9 w-full border border-input bg-transparent px-2 text-sm outline-none transition-colors focus:border-ring"
+                  disabled={orgsLoading || (movePlateOrganization.isPending && movingId === orgDialogPlate.id)}
+                >
+                  <option value="">Personal (no organization)</option>
+                  {organizations.map((org) => (
+                    <option key={org.id} value={org.id}>
+                      {org.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <DialogFooter className="gap-2 sm:justify-end">
+                <Button type="button" variant="outline" size="sm" onClick={() => setOrgDialogPlate(null)}>
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={orgsLoading || (movePlateOrganization.isPending && movingId === orgDialogPlate.id)}
+                  onClick={() => {
+                    const p = orgDialogPlate
+                    const currentOrgId = p.organization_id ?? ""
+                    const selectedOrgId = selectedOrgByPlate[p.id] ?? currentOrgId
+
+                    if (selectedOrgId === currentOrgId) {
+                      setMoveError("Select a different organization before moving this plate")
+                      return
+                    }
+
+                    const targetOrgName = selectedOrgId === ""
+                      ? "Personal (no organization)"
+                      : (organizations.find((org) => org.id === selectedOrgId)?.name ?? "selected organization")
+
+                    setMoveError(null)
+                    setMoveConfirmNameInput("")
+                    setOrgDialogPlate(null)
+                    setConfirmingMove({
+                      plateId: p.id,
+                      plateName: p.name,
+                      targetOrgId: selectedOrgId,
+                      targetOrgName,
+                    })
+                  }}
+                >
+                  {movePlateOrganization.isPending && movingId === orgDialogPlate.id ? "Moving…" : "Move"}
+                </Button>
+              </DialogFooter>
+            </>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+
+      <PlateGetBadgeModal plate={getBadgePlate} onClose={() => setGetBadgePlate(null)} />
 
       {confirmingPlate && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">

--- a/web/src/presentation/components/account/PlateGetBadgeModal.tsx
+++ b/web/src/presentation/components/account/PlateGetBadgeModal.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import { useState } from "react"
+import type { Plate } from "@/src/domain/entities/Plate"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Check, Copy } from "lucide-react"
+import { toast } from "sonner"
+
+function buildBadgeSnippets(plate: Plate) {
+  const origin = typeof window !== "undefined" ? window.location.origin : ""
+  const platePath = `/plates/${encodeURIComponent(plate.slug)}`
+  const plateUrl = `${origin}${platePath}`
+  const shieldLabel = encodeURIComponent(plate.slug)
+  const shieldUrl = `https://img.shields.io/badge/KikPlate-${shieldLabel}-0366d6?style=flat-square`
+  const markdown = `[![View on KikPlate](${shieldUrl})](${plateUrl})`
+  const asciidoc = `image:${shieldUrl}[View on KikPlate,link="${plateUrl}"]`
+  return { plateUrl, shieldUrl, markdown, asciidoc }
+}
+
+function CopyRow({
+  label,
+  value,
+  copyId,
+  activeCopy,
+  onCopy,
+}: {
+  label: string
+  value: string
+  copyId: string
+  activeCopy: string | null
+  onCopy: (id: string, text: string) => void
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</span>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 gap-1 px-2 text-xs"
+          onClick={() => onCopy(copyId, value)}
+        >
+          {activeCopy === copyId ? (
+            <Check className="h-3 w-3 text-green-600" />
+          ) : (
+            <Copy className="h-3 w-3" />
+          )}
+          Copy
+        </Button>
+      </div>
+      <pre className="max-h-36 overflow-auto whitespace-pre-wrap break-all border border-border bg-muted/30 p-3 font-mono text-[11px] leading-relaxed text-foreground">
+        {value}
+      </pre>
+    </div>
+  )
+}
+
+export function PlateGetBadgeModal({
+  plate,
+  onClose,
+}: {
+  plate: Plate | null
+  onClose: () => void
+}) {
+  const [activeCopy, setActiveCopy] = useState<string | null>(null)
+
+  async function handleCopy(id: string, text: string) {
+    try {
+      await navigator.clipboard.writeText(text)
+      setActiveCopy(id)
+      toast.success("Copied to clipboard")
+      setTimeout(() => setActiveCopy(null), 2000)
+    } catch {
+      toast.error("Could not copy")
+    }
+  }
+
+  const snippets = plate ? buildBadgeSnippets(plate) : null
+
+  return (
+    <Dialog open={Boolean(plate)} onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent className="max-h-[min(90vh,640px)] overflow-y-auto sm:max-w-lg">
+        {snippets && plate ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Get badge</DialogTitle>
+              <DialogDescription>
+                Preview how the badge looks, then copy Markdown or AsciiDoc for your repository.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Preview</p>
+              <div className="flex flex-wrap items-center gap-3 rounded-md border border-border bg-muted/20 px-4 py-4">
+                <a
+                  href={snippets.plateUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center"
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={snippets.shieldUrl} alt="View on KikPlate" className="max-w-full" />
+                </a>
+              </div>
+            </div>
+
+            <div className="space-y-4 border-t border-border pt-4">
+              <CopyRow
+                label="Markdown"
+                value={snippets.markdown}
+                copyId="md"
+                activeCopy={activeCopy}
+                onCopy={handleCopy}
+              />
+              <CopyRow
+                label="AsciiDoc"
+                value={snippets.asciidoc}
+                copyId="adoc"
+                activeCopy={activeCopy}
+                onCopy={handleCopy}
+              />
+            </div>
+          </>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/presentation/components/account/ProfileDetails.tsx
+++ b/web/src/presentation/components/account/ProfileDetails.tsx
@@ -32,6 +32,10 @@ interface Row {
   copyable?: string
 }
 
+function oauthOrTrustedProvider(provider: string): boolean {
+  return provider !== "local"
+}
+
 export function ProfileDetails({ me }: { me: MeResult }) {
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -70,18 +74,19 @@ export function ProfileDetails({ me }: { me: MeResult }) {
           value: <span className="text-sm capitalize">{me.role}</span>,
         }
       : null,
-    me.is_active !== undefined
+    oauthOrTrustedProvider(me.provider) || me.is_active !== undefined
       ? {
           label: "Email verified",
-          value: me.is_active ? (
-            <span className="flex items-center gap-1 text-sm text-green-600">
-              <CheckCircle2 className="h-3.5 w-3.5" /> Verified
-            </span>
-          ) : (
-            <span className="flex items-center gap-1 text-sm text-destructive">
-              <XCircle className="h-3.5 w-3.5" /> Not verified
-            </span>
-          ),
+          value:
+            oauthOrTrustedProvider(me.provider) || me.is_active === true ? (
+              <span className="flex items-center gap-1 text-sm text-green-600">
+                <CheckCircle2 className="h-3.5 w-3.5" /> Verified
+              </span>
+            ) : (
+              <span className="flex items-center gap-1 text-sm text-destructive">
+                <XCircle className="h-3.5 w-3.5" /> Not verified
+              </span>
+            ),
         }
       : null,
   ].filter(Boolean) as Row[]

--- a/web/src/presentation/components/auth/LoginForm.tsx
+++ b/web/src/presentation/components/auth/LoginForm.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label"
 import { OAuthButton } from "./OAuthButton"
 import { toast } from "sonner"
 import { Loader2 } from "lucide-react"
+import { ApiError } from "@/src/data/repositories/httpClient"
 
 export function LoginForm() {
   const router = useRouter()
@@ -27,6 +28,17 @@ export function LoginForm() {
       router.push("/")
       router.refresh()
     } catch (err: unknown) {
+      if (
+        err instanceof ApiError &&
+        err.isForbidden() &&
+        err.message.toLowerCase().includes("email")
+      ) {
+        toast.error("Email not verified yet", {
+          description:
+            "Use the link in your inbox from when you signed up. After that, email and password sign-in will work.",
+        })
+        return
+      }
       toast.error(err instanceof Error ? err.message : "Login failed")
     }
   }

--- a/web/src/presentation/components/plates/PendingVerification.tsx
+++ b/web/src/presentation/components/plates/PendingVerification.tsx
@@ -1,9 +1,15 @@
 "use client"
 
 import { useState } from "react"
-import { Copy, Check, AlertCircle, RotateCw, Trash2 } from "lucide-react"
+import { Copy, Check, AlertCircle, MoreVertical, RotateCw, Trash2 } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import type { Plate } from "@/src/domain/entities/Plate"
 import { useVerifyRepository } from "@/src/presentation/hooks/usePlates"
 
@@ -44,12 +50,33 @@ export function PendingVerification({ plate, onRemove, removing = false }: Props
     <div className="space-y-4 rounded-lg border border-amber-300/40 bg-amber-50/50 p-4 dark:border-amber-400/30 dark:bg-amber-950/20">
       <div className="flex items-start gap-3">
         <AlertCircle className="mt-0.5 h-5 w-5 text-amber-600 dark:text-amber-400 shrink-0" />
-        <div className="flex-1 space-y-3">
-          <div>
-            <p className="font-semibold text-amber-900 dark:text-amber-100">Verification Pending</p>
-            <p className="mt-1 text-sm text-amber-800 dark:text-amber-200">
-              To publish this plate, add the verification token to your kikplate.yaml and push it to the repository.
-            </p>
+        <div className="min-w-0 flex-1 space-y-3">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="font-semibold text-amber-900 dark:text-amber-100">Verification Pending</p>
+              <p className="mt-1 text-sm text-amber-800 dark:text-amber-200">
+                To publish this plate, add the verification token to your kikplate.yaml and push it to the repository.
+              </p>
+            </div>
+            {onRemove ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-none border border-transparent text-amber-800 outline-none transition-colors hover:border-amber-400/50 hover:bg-amber-100/60 hover:text-amber-950 focus-visible:border-amber-500 focus-visible:ring-2 focus-visible:ring-amber-500/40 dark:text-amber-200 dark:hover:bg-amber-950/40 dark:hover:text-amber-50">
+                  <MoreVertical className="h-4 w-4" />
+                  <span className="sr-only">Pending plate actions</span>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    variant="destructive"
+                    className="cursor-pointer gap-2"
+                    disabled={removing}
+                    onClick={() => onRemove(plate)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    {removing ? "Removing…" : "Remove plate"}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
           </div>
 
           <div className="space-y-2">
@@ -83,19 +110,6 @@ export function PendingVerification({ plate, onRemove, removing = false }: Props
                 {verifyMutation.isPending && <RotateCw className="h-4 w-4 animate-spin" />}
                 {verifyMutation.isPending ? "Verifying..." : "Retry Verification"}
               </Button>
-              {onRemove && (
-                <Button
-                  type="button"
-                  variant="destructive"
-                  size="sm"
-                  onClick={() => onRemove(plate)}
-                  disabled={removing}
-                  className="gap-2"
-                >
-                  <Trash2 className="h-4 w-4" />
-                  {removing ? "Removing..." : "Remove Plate"}
-                </Button>
-              )}
             </div>
           </div>
 


### PR DESCRIPTION
Email verification
- Treat OAuth and non-local providers as email-verified in account profile details.
- On login, map 403 responses that mention email to a clear “verify your inbox” toast instead of a generic error.
My plates (published)
- Move secondary actions into a three-dots menu (badge, token copy, organization move, remove).
- Add an organization picker dialog before the existing name-confirmation move flow.
- Show organization on the card when the plate belongs to an org (payload or “my orgs” fallback).
- Remove the redundant “View plate” item; the whole card navigates to the plate via a stretch link, with pointer events only on the menu trigger.
Pending verification
- Move “Remove” into the same three-dots pattern as published cards.
Shared UI
- Size dropdown menus from content (min width + max width) instead of tying width to the trigger only.
Plate detail
- Place “Related plates” after the repository (GitHub) block in the sidebar.
Refactor
- Extract badge instructions into PlateGetBadgeModal for reuse from OwnedPlates.