### PR TITLE
feat: plate taxonomy, submit UX, README links, and badge chips on lists

### DIFF
--- a/api/command/sync.go
+++ b/api/command/sync.go
@@ -53,7 +53,7 @@ func (c *SyncCommand) Run() lib.CommandRunner {
 					if p == nil {
 						continue
 					}
-					syncOnePlate(ctx, logger, plateRepo, plateTagRepo, p, defaultSyncInterval)
+					syncOnePlate(ctx, logger, plateRepo, plateTagRepo, env, p, defaultSyncInterval)
 				}
 			}
 
@@ -67,6 +67,7 @@ func syncOnePlate(
 	logger lib.Logger,
 	plateRepo repository.PlateRepository,
 	plateTagRepo repository.PlateTagRepository,
+	env lib.Env,
 	plate *model.Plate,
 	defaultSyncInterval time.Duration,
 ) {
@@ -193,7 +194,7 @@ func syncOnePlate(
 	}
 
 	if isVerified {
-		if err := syncPlateManifest(ctx, plateRepo, plateTagRepo, plate, manifest, metadataJSON); err != nil {
+		if err := syncPlateManifest(ctx, plateRepo, plateTagRepo, env, plate, manifest, metadataJSON); err != nil {
 			failed := model.SyncStatusFailed
 			errText := fmt.Sprintf("failed to persist manifest changes: %v", err)
 			desiredVisibility = model.PlateVisibilityPrivate
@@ -249,12 +250,13 @@ func syncPlateManifest(
 	ctx context.Context,
 	plateRepo repository.PlateRepository,
 	plateTagRepo repository.PlateTagRepository,
+	env lib.Env,
 	plate *model.Plate,
 	manifest *syncKickplateYAML,
 	metadataJSON []byte,
 ) error {
 	plate.Name = manifest.Name
-	plate.Category = manifest.Category
+	plate.Category = lib.NormalizePlateCategory(env, manifest.Category)
 	plate.Metadata = metadataJSON
 
 	if strings.TrimSpace(manifest.Description) == "" {

--- a/api/handler/handlers/config_handler.go
+++ b/api/handler/handlers/config_handler.go
@@ -15,7 +15,15 @@ func NewConfigHandler(env lib.Env) ConfigHandler {
 	return ConfigHandler{env: env}
 }
 
+type appConfigResponse struct {
+	lib.Customization
+	PlateCategories []lib.PlateCategoryConfig `json:"plate_categories"`
+}
+
 func (h ConfigHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(h.env.Customization)
+	json.NewEncoder(w).Encode(appConfigResponse{
+		Customization:   h.env.Customization,
+		PlateCategories: lib.EffectivePlateCategories(h.env),
+	})
 }

--- a/api/lib/env.go
+++ b/api/lib/env.go
@@ -80,6 +80,7 @@ type Env struct {
 	SMTP              SMTPConfig
 	Customization     Customization
 	Badges            []BadgeConfig
+	PlateCategories   []PlateCategoryConfig
 }
 
 func (e Env) GetOAuthProvider(name string) (OAuthProvider, bool) {
@@ -279,6 +280,11 @@ func NewEnv() Env {
 	var badges []BadgeConfig
 	if err := viper.UnmarshalKey("badges", &badges); err == nil {
 		env.Badges = badges
+	}
+
+	var plateCategories []PlateCategoryConfig
+	if err := viper.UnmarshalKey("plate_categories", &plateCategories); err == nil {
+		env.PlateCategories = plateCategories
 	}
 
 	return env

--- a/api/lib/plate_category.go
+++ b/api/lib/plate_category.go
@@ -1,0 +1,119 @@
+package lib
+
+import "strings"
+
+type PlateCategoryConfig struct {
+	Slug        string `mapstructure:"slug" json:"slug"`
+	Label       string `mapstructure:"label" json:"label"`
+	Description string `mapstructure:"description" json:"description"`
+	Icon        string `mapstructure:"icon" json:"icon"`
+}
+
+const plateCategoryFallbackSlug = "other"
+
+func DefaultPlateCategories() []PlateCategoryConfig {
+	return []PlateCategoryConfig{
+		{Slug: "backend", Label: "Backend", Description: "APIs, services, microservices", Icon: "server"},
+		{Slug: "frontend", Label: "Frontend", Description: "Web UIs, SPAs, SSR apps", Icon: "globe"},
+		{Slug: "fullstack", Label: "Full Stack", Description: "End-to-end project starters", Icon: "layers"},
+		{Slug: "mobile", Label: "Mobile", Description: "iOS, Android, cross-platform", Icon: "smartphone"},
+		{Slug: "cli", Label: "CLI", Description: "Command line tools & scripts", Icon: "terminal"},
+		{Slug: "devops", Label: "DevOps", Description: "Docker, CI/CD, infrastructure", Icon: "wrench"},
+		{Slug: "library", Label: "Library", Description: "Reusable packages and SDKs", Icon: "package"},
+		{Slug: "database", Label: "Database", Description: "Schemas, migrations, seeds", Icon: "database"},
+		{Slug: "cloud", Label: "Cloud", Description: "AWS, GCP, Azure starters", Icon: "cloud"},
+		{Slug: "security", Label: "Security", Description: "Auth, encryption, compliance", Icon: "shield"},
+		{Slug: "iot", Label: "IoT", Description: "Embedded, edge, hardware", Icon: "cpu"},
+		{Slug: "game", Label: "Game Dev", Description: "Game engines, frameworks", Icon: "gamepad-2"},
+		{Slug: "documentation", Label: "Documentation", Description: "Docs sites, wikis, guides", Icon: "book-open"},
+		{Slug: "ai-ml", Label: "AI / ML", Description: "Machine learning, LLMs, data", Icon: "bot"},
+		{Slug: "other", Label: "Other", Description: "Everything else", Icon: "more-horizontal"},
+	}
+}
+
+func EffectivePlateCategories(env Env) []PlateCategoryConfig {
+	var base []PlateCategoryConfig
+	if len(env.PlateCategories) > 0 {
+		base = append([]PlateCategoryConfig{}, env.PlateCategories...)
+	} else {
+		base = DefaultPlateCategories()
+	}
+	if !plateCategoriesContainSlugCI(base, plateCategoryFallbackSlug) {
+		for _, d := range DefaultPlateCategories() {
+			if strings.EqualFold(strings.TrimSpace(d.Slug), plateCategoryFallbackSlug) {
+				base = append(base, d)
+				break
+			}
+		}
+	}
+	return base
+}
+
+func plateCategoriesContainSlugCI(list []PlateCategoryConfig, slug string) bool {
+	want := strings.ToLower(strings.TrimSpace(slug))
+	for _, c := range list {
+		if strings.ToLower(strings.TrimSpace(c.Slug)) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func plateCategoryCanonByLowerKey(env Env) map[string]string {
+	out := make(map[string]string)
+	for _, c := range EffectivePlateCategories(env) {
+		slug := strings.TrimSpace(c.Slug)
+		if slug == "" {
+			continue
+		}
+		out[strings.ToLower(slug)] = slug
+	}
+	return out
+}
+
+func NormalizePlateCategory(env Env, raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return resolveFallbackCanonSlug(env)
+	}
+	if canon, ok := plateCategoryCanonByLowerKey(env)[strings.ToLower(s)]; ok {
+		return canon
+	}
+	return resolveFallbackCanonSlug(env)
+}
+
+func resolveFallbackCanonSlug(env Env) string {
+	idx := plateCategoryCanonByLowerKey(env)
+	if canon, ok := idx[strings.ToLower(plateCategoryFallbackSlug)]; ok {
+		return canon
+	}
+	return plateCategoryFallbackSlug
+}
+
+func PlateCategorySlugs(env Env) []string {
+	cats := EffectivePlateCategories(env)
+	out := make([]string, 0, len(cats))
+	for _, c := range cats {
+		if s := strings.TrimSpace(c.Slug); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func NormalizePlateCategoryFilter(env Env, in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(in))
+	for _, c := range in {
+		n := NormalizePlateCategory(env, c)
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	return out
+}

--- a/api/repository/postgres/plate.go
+++ b/api/repository/postgres/plate.go
@@ -104,6 +104,7 @@ func (r *plateRepository) List(ctx context.Context, filter repository.PlateFilte
 	if filter.Search != "" {
 		result = q.
 			Preload("Tags").
+			Preload("Badges.Badge").
 			Preload("Organization").
 			Preload("Organization.Owner").
 			Offset((page - 1) * limit).
@@ -113,6 +114,7 @@ func (r *plateRepository) List(ctx context.Context, filter repository.PlateFilte
 	} else {
 		result = q.
 			Preload("Tags").
+			Preload("Badges.Badge").
 			Preload("Organization").
 			Preload("Organization.Owner").
 			Offset((page - 1) * limit).

--- a/api/service/plate/lifecycle_ops.go
+++ b/api/service/plate/lifecycle_ops.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kickplate/api/lib"
 	"github.com/kickplate/api/model"
 	"gorm.io/gorm"
 )
@@ -27,7 +28,7 @@ func (s *plateService) Update(ctx context.Context, plateID uuid.UUID, accountID 
 		plate.Description = input.Description
 	}
 	if input.Category != nil {
-		plate.Category = *input.Category
+		plate.Category = lib.NormalizePlateCategory(s.env, *input.Category)
 	}
 	if input.Visibility != nil {
 		plate.Visibility = *input.Visibility

--- a/api/service/plate/read_ops.go
+++ b/api/service/plate/read_ops.go
@@ -3,9 +3,11 @@ package plate
 import (
 	"context"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/kickplate/api/lib"
 	"github.com/kickplate/api/model"
 	"github.com/kickplate/api/repository"
 )
@@ -79,6 +81,7 @@ func (s *plateService) GetBySlug(ctx context.Context, slug string, requesterID u
 }
 
 func (s *plateService) List(ctx context.Context, filter repository.PlateFilter, requesterID uuid.UUID) ([]*model.Plate, int, error) {
+	filter.Categories = lib.NormalizePlateCategoryFilter(s.env, filter.Categories)
 	plates, total, err := s.plates.List(ctx, filter)
 	if err != nil {
 		return nil, 0, err
@@ -124,11 +127,25 @@ func (s *plateService) List(ctx context.Context, filter repository.PlateFilter, 
 }
 
 func (s *plateService) GetStats(ctx context.Context) (*repository.PlateStats, error) {
-	return s.plates.GetStats(ctx)
+	st, err := s.plates.GetStats(ctx)
+	if err != nil {
+		return nil, err
+	}
+	counts, err := s.GetCategoryCounts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	st.TotalCategories = int64(len(counts))
+	return st, nil
 }
 
 func (s *plateService) GetFilterOptions(ctx context.Context) (*repository.PlateFilterOptions, error) {
-	return s.plates.GetFilterOptions(ctx)
+	opts, err := s.plates.GetFilterOptions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	opts.Categories = lib.PlateCategorySlugs(s.env)
+	return opts, nil
 }
 
 func (s *plateService) GetMonthlyGrowth(ctx context.Context, months int) ([]repository.MonthlyCount, error) {
@@ -136,7 +153,28 @@ func (s *plateService) GetMonthlyGrowth(ctx context.Context, months int) ([]repo
 }
 
 func (s *plateService) GetCategoryCounts(ctx context.Context) ([]repository.CategoryCount, error) {
-	return s.plates.GetCategoryCounts(ctx)
+	rows, err := s.plates.GetCategoryCounts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	merged := make(map[string]int64)
+	for _, row := range rows {
+		k := lib.NormalizePlateCategory(s.env, row.Category)
+		merged[k] += row.Count
+	}
+	out := make([]repository.CategoryCount, 0, len(merged))
+	for k, v := range merged {
+		if v > 0 {
+			out = append(out, repository.CategoryCount{Category: k, Count: v})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].Category < out[j].Category
+	})
+	return out, nil
 }
 
 func (s *plateService) GetTopBookmarked(ctx context.Context, limit int) ([]repository.PlateRanked, error) {

--- a/api/service/plate/submit_repository.go
+++ b/api/service/plate/submit_repository.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kickplate/api/lib"
 	"github.com/kickplate/api/model"
 	"gorm.io/gorm"
 )
@@ -79,7 +80,7 @@ func (s *plateService) SubmitRepository(ctx context.Context, accountID uuid.UUID
 		Type:                   model.PlateTypeRepository,
 		Slug:                   slugify(kp.Name),
 		Name:                   kp.Name,
-		Category:               kp.Category,
+		Category:               lib.NormalizePlateCategory(s.env, kp.Category),
 		Status:                 model.PlateStatusPending,
 		Visibility:             model.PlateVisibilityPrivate,
 		Metadata:               metadata,

--- a/config/examples/config.yaml.example
+++ b/config/examples/config.yaml.example
@@ -100,3 +100,67 @@ customization:
     - "Gin framework"
     - "Postgresql docker-compose"
     - "Nginx"
+
+# Allowed values for kikplate.yaml `category`, browse-by-category UI, and filters.
+# Omit this key to use the built-in default list. Unknown or empty categories map to `other`.
+plate_categories:
+  - slug: backend
+    label: Backend
+    description: APIs, services, microservices
+    icon: server
+  - slug: frontend
+    label: Frontend
+    description: Web UIs, SPAs, SSR apps
+    icon: globe
+  - slug: fullstack
+    label: Full Stack
+    description: End-to-end project starters
+    icon: layers
+  - slug: mobile
+    label: Mobile
+    description: iOS, Android, cross-platform
+    icon: smartphone
+  - slug: cli
+    label: CLI
+    description: Command line tools & scripts
+    icon: terminal
+  - slug: devops
+    label: DevOps
+    description: Docker, CI/CD, infrastructure
+    icon: wrench
+  - slug: library
+    label: Library
+    description: Reusable packages and SDKs
+    icon: package
+  - slug: database
+    label: Database
+    description: Schemas, migrations, seeds
+    icon: database
+  - slug: cloud
+    label: Cloud
+    description: AWS, GCP, Azure starters
+    icon: cloud
+  - slug: security
+    label: Security
+    description: Auth, encryption, compliance
+    icon: shield
+  - slug: iot
+    label: IoT
+    description: Embedded, edge, hardware
+    icon: cpu
+  - slug: game
+    label: Game Dev
+    description: Game engines, frameworks
+    icon: gamepad-2
+  - slug: documentation
+    label: Documentation
+    description: Docs sites, wikis, guides
+    icon: book-open
+  - slug: ai-ml
+    label: AI / ML
+    description: Machine learning, LLMs, data
+    icon: bot
+  - slug: other
+    label: Other
+    description: Everything else
+    icon: more-horizontal

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,6 +224,46 @@ badges:
 
 Supported `tier` values are `official` and `community`. Badge icons use the Lucide icon name format.
 
+### plate_categories
+
+Defines the **allowed plate taxonomy**: which `category` values are valid in `kikplate.yaml`, how they appear in the web app (home “browse by category”, explore filters, stats), and how the API normalizes categories when ingesting manifests.
+
+#### `category` in `kikplate.yaml`
+
+Repository authors set `category` to the **`slug`** of one entry in `plate_categories`. Matching is **case-insensitive** after trimming whitespace. If the field is omitted, empty, or not in the list, the stored category becomes the slug used for “other” (by default `other`). Submit and sync **do not fail** on a bad category value.
+
+The authoritative list of allowed slugs for a deployment is whatever appears under `plate_categories` in that deployment’s YAML. If you omit the whole `plate_categories` key, the API falls back to a built-in default set (backend, frontend, fullstack, mobile, cli, devops, library, database, cloud, security, iot, game, documentation, ai-ml, other). Operators who customize the list should keep an explicit catch-all (typically `other`) so every manifest maps cleanly.
+
+```yaml
+plate_categories:
+  - slug: backend
+    label: Backend
+    description: APIs, services, microservices
+    icon: server
+  - slug: other
+    label: Other
+    description: Everything else
+    icon: more-horizontal
+```
+
+| Field | Description |
+|-------|-------------|
+| `slug` | Stored on the plate and used in URLs and filters. Must be unique in the list. |
+| `label` | Human-readable title in the UI. |
+| `description` | Short helper text (for example on the home page category grid). |
+| `icon` | Lucide icon name in kebab-case (for example `book-open`, `more-horizontal`), same style as badge icons. |
+
+If you supply a custom list without an `other`-like slug, the API appends the default “other” entry so normalization always has a target.
+
+### Public app config (`GET /config`)
+
+The API exposes **non-secret** UI settings for the Next.js app. Today that response includes:
+
+- All keys under `customization` (logo, banner, social links, prepared search queries, and so on).
+- `plate_categories`: the effective list after defaults are applied, as described above.
+
+Database credentials, JWT secrets, and OAuth client secrets are **not** included.
+
 ## Kubernetes and Helm
 
 In Kubernetes, the config file is stored in a ConfigMap and mounted at `/app/config/config.yaml`. Secrets such as `JWT_SECRET` and OAuth client secrets are stored in a Kubernetes Secret and injected as environment variables.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -39,6 +39,17 @@ tags:
   - chi
 ```
 
+#### Manifest fields
+
+| Field | Required | Notes |
+|-------|----------|--------|
+| `name` | Yes | Becomes the plate display name and basis for the public slug. Must be unique across the platform when combined with the owner namespace. |
+| `owner` | Yes | Must match the submitting user’s **username** or the selected **organization name**. |
+| `description` | No | Free text shown on the plate page. |
+| `category` | No | Must be one of the **slugs** defined under `plate_categories` in the server `config.yaml` (match is case-insensitive). If omitted or not recognized, the platform stores the template under the **other** category—submission does not fail. See [Configuration](configuration.md#plate_categories). |
+| `tags` | No | A list of short labels used for search and filters. |
+| `verification_token` | After submit | Omitted on first submit. After Kikplate issues a token, add it to the file and run verify so the plate can go public. |
+
 ### Badge
 
 Badges are quality signals awarded to plates. They are defined in `config/config.yaml` under the `badges` key and seeded into the database. There are two tiers:

--- a/helm/templates/app-config-configmap.yaml
+++ b/helm/templates/app-config-configmap.yaml
@@ -57,3 +57,11 @@ data:
         icon: {{ .icon }}
         tier: {{ .tier }}
       {{- end }}
+
+    plate_categories:
+      {{- range .Values.config.plateCategories }}
+      - slug: {{ .slug }}
+        label: {{ .label | quote }}
+        description: {{ .description | quote }}
+        icon: {{ .icon }}
+      {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -238,3 +238,64 @@ config:
       description: Built using microservices architecture
       icon: layers
       tier: community
+  plateCategories:
+    - slug: backend
+      label: Backend
+      description: APIs, services, microservices
+      icon: server
+    - slug: frontend
+      label: Frontend
+      description: Web UIs, SPAs, SSR apps
+      icon: globe
+    - slug: fullstack
+      label: Full Stack
+      description: End-to-end project starters
+      icon: layers
+    - slug: mobile
+      label: Mobile
+      description: iOS, Android, cross-platform
+      icon: smartphone
+    - slug: cli
+      label: CLI
+      description: Command line tools & scripts
+      icon: terminal
+    - slug: devops
+      label: DevOps
+      description: Docker, CI/CD, infrastructure
+      icon: wrench
+    - slug: library
+      label: Library
+      description: Reusable packages and SDKs
+      icon: package
+    - slug: database
+      label: Database
+      description: Schemas, migrations, seeds
+      icon: database
+    - slug: cloud
+      label: Cloud
+      description: AWS, GCP, Azure starters
+      icon: cloud
+    - slug: security
+      label: Security
+      description: Auth, encryption, compliance
+      icon: shield
+    - slug: iot
+      label: IoT
+      description: Embedded, edge, hardware
+      icon: cpu
+    - slug: game
+      label: Game Dev
+      description: Game engines, frameworks
+      icon: gamepad-2
+    - slug: documentation
+      label: Documentation
+      description: Docs sites, wikis, guides
+      icon: book-open
+    - slug: ai-ml
+      label: AI / ML
+      description: Machine learning, LLMs, data
+      icon: bot
+    - slug: other
+      label: Other
+      description: Everything else
+      icon: more-horizontal

--- a/kubernetes/base/app-config-configmap.yaml
+++ b/kubernetes/base/app-config-configmap.yaml
@@ -67,6 +67,68 @@ data:
         - Postgresql docker-compose
         - Nginx
 
+    plate_categories:
+      - slug: backend
+        label: Backend
+        description: APIs, services, microservices
+        icon: server
+      - slug: frontend
+        label: Frontend
+        description: Web UIs, SPAs, SSR apps
+        icon: globe
+      - slug: fullstack
+        label: Full Stack
+        description: End-to-end project starters
+        icon: layers
+      - slug: mobile
+        label: Mobile
+        description: iOS, Android, cross-platform
+        icon: smartphone
+      - slug: cli
+        label: CLI
+        description: Command line tools & scripts
+        icon: terminal
+      - slug: devops
+        label: DevOps
+        description: Docker, CI/CD, infrastructure
+        icon: wrench
+      - slug: library
+        label: Library
+        description: Reusable packages and SDKs
+        icon: package
+      - slug: database
+        label: Database
+        description: Schemas, migrations, seeds
+        icon: database
+      - slug: cloud
+        label: Cloud
+        description: AWS, GCP, Azure starters
+        icon: cloud
+      - slug: security
+        label: Security
+        description: Auth, encryption, compliance
+        icon: shield
+      - slug: iot
+        label: IoT
+        description: Embedded, edge, hardware
+        icon: cpu
+      - slug: game
+        label: Game Dev
+        description: Game engines, frameworks
+        icon: gamepad-2
+      - slug: documentation
+        label: Documentation
+        description: Docs sites, wikis, guides
+        icon: book-open
+      - slug: ai-ml
+        label: AI / ML
+        description: Machine learning, LLMs, data
+        icon: bot
+      - slug: other
+        label: Other
+        description: Everything else
+        icon: more-horizontal
+
     badges:
       - slug: official
         name: Official

--- a/web/app/(main)/plates/[slug]/page.tsx
+++ b/web/app/(main)/plates/[slug]/page.tsx
@@ -174,7 +174,13 @@ export default async function PlateDetailPage({ params }: Props) {
         <div className="grid grid-cols-1 gap-7 xl:gap-8 lg:grid-cols-12">
           <section className="lg:col-span-9">
             <div>
-              <PlateContentTabs readme={readme} license={license} tree={tree} />
+              <PlateContentTabs
+                readme={readme}
+                license={license}
+                tree={tree}
+                repoUrl={plate.repo_url}
+                branch={plate.branch ?? undefined}
+              />
             </div>
           </section>
 

--- a/web/app/(main)/submit/page.tsx
+++ b/web/app/(main)/submit/page.tsx
@@ -47,7 +47,7 @@ export default function SubmitPage() {
         </div>
       </div>
 
-      <div className="container mx-auto px-4 py-10 max-w-2xl">
+      <div className="container mx-auto px-4 py-10 max-w-6xl">
         <SubmitRepositoryForm />
       </div>
     </div>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -2,13 +2,27 @@ import { HeroSearch } from "@/src/presentation/components/common/HeroSearch"
 import { FeaturedPlates } from "@/src/presentation/components/plates/FeaturedPlates"
 import { CategoriesGrid } from "@/src/presentation/components/common/CategoriesGrid"
 import { StatsBanner } from "@/src/presentation/components/common/StatsBanner"
+import type { AppConfig, PlateCategory } from "@/src/domain/entities/Config"
+import { getServerApiBaseUrl } from "@/src/lib/api"
 
-export default function HomePage() {
+export default async function HomePage() {
+  const base = await getServerApiBaseUrl()
+  let plateCategories: PlateCategory[] = []
+  try {
+    const res = await fetch(`${base}/config`, { cache: "no-store" })
+    if (res.ok) {
+      const cfg = (await res.json()) as AppConfig
+      plateCategories = cfg.plate_categories ?? []
+    }
+  } catch {
+    plateCategories = []
+  }
+
   return (
     <div>
       <HeroSearch />
       <FeaturedPlates />
-      <CategoriesGrid />
+      <CategoriesGrid categories={plateCategories} />
       <StatsBanner />
     </div>
   )

--- a/web/src/data/repositories/githubClient.ts
+++ b/web/src/data/repositories/githubClient.ts
@@ -3,7 +3,7 @@ function repoToRaw(repoUrl: string, branch: string, file: string): string {
   return `https://raw.githubusercontent.com/${path}/${branch}/${file}`
 }
 
-function repoToPath(repoUrl: string): string {
+export function repoToPath(repoUrl: string): string {
   return repoUrl
     .replace("https://github.com/", "")
     .replace("http://github.com/", "")

--- a/web/src/domain/entities/Config.ts
+++ b/web/src/domain/entities/Config.ts
@@ -1,7 +1,15 @@
+export interface PlateCategory {
+  slug: string
+  label: string
+  description: string
+  icon: string
+}
+
 export interface AppConfig {
   logo: string
   banner_title: string
   badge_request_url?: string
   social_media: Array<{ type: string; link: string }>
   prepared_queries: string[]
+  plate_categories?: PlateCategory[]
 }

--- a/web/src/presentation/components/common/CategoriesGrid.tsx
+++ b/web/src/presentation/components/common/CategoriesGrid.tsx
@@ -1,32 +1,19 @@
 "use client"
 
 import { useRouter } from "next/navigation"
-import {
-  Server, Globe, Layers, Smartphone,
-  Terminal, Package, Wrench, MoreHorizontal,
-  Database, Cloud, Shield, Cpu, Gamepad2, BookOpen, Bot
-} from "lucide-react"
+import { getPlateCategoryIcon } from "@/src/presentation/utils/plateCategoryIcons"
+import type { PlateCategory } from "@/src/domain/entities/Config"
 
-const CATEGORIES = [
-  { slug: "backend",        label: "Backend",        icon: Server,         description: "APIs, services, microservices" },
-  { slug: "frontend",       label: "Frontend",       icon: Globe,          description: "Web UIs, SPAs, SSR apps" },
-  { slug: "fullstack",      label: "Full Stack",     icon: Layers,         description: "End-to-end project starters" },
-  { slug: "mobile",         label: "Mobile",         icon: Smartphone,     description: "iOS, Android, cross-platform" },
-  { slug: "cli",            label: "CLI",            icon: Terminal,       description: "Command line tools & scripts" },
-  { slug: "devops",         label: "DevOps",         icon: Wrench,         description: "Docker, CI/CD, infrastructure" },
-  { slug: "library",        label: "Library",        icon: Package,        description: "Reusable packages and SDKs" },
-  { slug: "database",       label: "Database",       icon: Database,       description: "Schemas, migrations, seeds" },
-  { slug: "cloud",          label: "Cloud",          icon: Cloud,          description: "AWS, GCP, Azure starters" },
-  { slug: "security",       label: "Security",       icon: Shield,         description: "Auth, encryption, compliance" },
-  { slug: "iot",            label: "IoT",            icon: Cpu,            description: "Embedded, edge, hardware" },
-  { slug: "game",           label: "Game Dev",       icon: Gamepad2,       description: "Game engines, frameworks" },
-  { slug: "documentation",  label: "Documentation",  icon: BookOpen,       description: "Docs sites, wikis, guides" },
-  { slug: "ai-ml",          label: "AI / ML",        icon: Bot,            description: "Machine learning, LLMs, data" },
-  { slug: "other",          label: "Other",          icon: MoreHorizontal, description: "Everything else" },
-]
+interface Props {
+  categories: PlateCategory[]
+}
 
-export function CategoriesGrid() {
+export function CategoriesGrid({ categories }: Props) {
   const router = useRouter()
+
+  if (categories.length === 0) {
+    return null
+  }
 
   return (
     <section className="bg-background py-20">
@@ -42,25 +29,28 @@ export function CategoriesGrid() {
               Find templates by domain, from backend services to AI pipelines and infrastructure.
             </p>
           </div>
-          <p className="text-xs tabular-nums text-muted-foreground border border-border bg-card px-3 py-1.5">{CATEGORIES.length} domains</p>
+          <p className="text-xs tabular-nums text-muted-foreground border border-border bg-card px-3 py-1.5">{categories.length} domains</p>
         </div>
 
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
-          {CATEGORIES.map(({ slug, label, icon: Icon, description }) => (
-            <button
-              key={slug}
-              onClick={() => router.push(`/explore?category=${slug}`)}
-              className="group flex items-start gap-3 border border-border bg-card p-4 text-left transition-all hover:border-foreground/20 hover:bg-background hover:-translate-y-0.5"
-            >
-              <div className="mt-0.5 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground">
-                <Icon className="h-4 w-4" />
-              </div>
-              <div className="min-w-0">
-                <p className="text-sm font-semibold text-foreground">{label}</p>
-                <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
-              </div>
-            </button>
-          ))}
+          {categories.map(({ slug, label, description, icon }) => {
+            const Icon = getPlateCategoryIcon(icon)
+            return (
+              <button
+                key={slug}
+                onClick={() => router.push(`/explore?category=${encodeURIComponent(slug)}`)}
+                className="group flex items-start gap-3 border border-border bg-card p-4 text-left transition-all hover:border-foreground/20 hover:bg-background hover:-translate-y-0.5"
+              >
+                <div className="mt-0.5 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground">
+                  <Icon className="h-4 w-4" />
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-foreground">{label}</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+                </div>
+              </button>
+            )
+          })}
         </div>
 
       </div>

--- a/web/src/presentation/components/plates/FeaturedPlates.tsx
+++ b/web/src/presentation/components/plates/FeaturedPlates.tsx
@@ -5,6 +5,7 @@ import { usePlates } from "@/src/presentation/hooks/usePlates"
 import { GitBranch, Star, Heart, ArrowRight, Sparkles, Terminal, CheckCircle2 } from "lucide-react"
 import { formatCount } from "@/src/presentation/utils/plateUtils"
 import type { Plate } from "@/src/domain/entities/Plate"
+import { PlateBadgeChips } from "@/src/presentation/components/plates/PlateBadgeChips"
 import { buttonVariants } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
@@ -39,6 +40,7 @@ function FeaturedPlateCard({ plate, index }: { plate: Plate; index: number }) {
             {plate.description}
           </p>
         )}
+        <PlateBadgeChips badges={plate.badges} max={3} className="mt-2" />
       </div>
 
       <div className="mt-auto flex items-center justify-between border-t border-border pt-3">

--- a/web/src/presentation/components/plates/PlateBadgeChips.tsx
+++ b/web/src/presentation/components/plates/PlateBadgeChips.tsx
@@ -1,0 +1,40 @@
+import type { PlateBadge } from "@/src/domain/entities/Plate"
+import { cn } from "@/lib/utils"
+import { getBadgeIcon } from "@/src/presentation/utils/badgeIcons"
+import { tierColour } from "@/src/presentation/utils/plateUtils"
+
+interface Props {
+  badges?: PlateBadge[]
+  max?: number
+  className?: string
+}
+
+export function PlateBadgeChips({ badges, max = 3, className = "" }: Props) {
+  const withBadge = badges?.filter((pb) => pb.badge) ?? []
+  if (withBadge.length === 0) return null
+
+  const shown = withBadge.slice(0, max)
+
+  return (
+    <div className={cn("flex flex-wrap gap-1", className)}>
+      {shown.map((pb) => {
+        const b = pb.badge!
+        const Icon = getBadgeIcon(b.slug)
+        return (
+          <span
+            key={pb.id}
+            className={`inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] border font-medium ${tierColour(b.tier)}`}
+          >
+            <Icon className="h-2.5 w-2.5 shrink-0" />
+            {b.name}
+          </span>
+        )
+      })}
+      {withBadge.length > max ? (
+        <span className="self-center text-[10px] text-muted-foreground/60 tabular-nums">
+          +{withBadge.length - max}
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/presentation/components/plates/PlateCard.tsx
+++ b/web/src/presentation/components/plates/PlateCard.tsx
@@ -3,10 +3,11 @@
 import Link from "next/link"
 import {
   GitBranch, Heart, Star,
-  Shield, Tag, CheckCircle2, AlertTriangle
+  Tag, CheckCircle2, AlertTriangle
 } from "lucide-react"
 import type { Plate } from "@/src/domain/entities/Plate"
-import { formatCount, tierColour } from "@/src/presentation/utils/plateUtils"
+import { formatCount } from "@/src/presentation/utils/plateUtils"
+import { PlateBadgeChips } from "@/src/presentation/components/plates/PlateBadgeChips"
 
 export function PlateCard({ plate }: { plate: Plate }) {
   return (
@@ -60,19 +61,7 @@ export function PlateCard({ plate }: { plate: Plate }) {
         </div>
       )}
 
-      {plate.badges && plate.badges.length > 0 && (
-        <div className="px-4 pb-3 flex flex-wrap gap-1">
-          {plate.badges.slice(0, 3).map((pb) => pb.badge && (
-            <span
-              key={pb.id}
-              className={`inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] border font-medium ${tierColour(pb.badge.tier)}`}
-            >
-              <Shield className="h-2.5 w-2.5" />
-              {pb.badge.name}
-            </span>
-          ))}
-        </div>
-      )}
+      <PlateBadgeChips badges={plate.badges} max={3} className="px-4 pb-3" />
 
       <div className="mt-auto flex items-center justify-between px-4 py-3 border-t border-border bg-muted/20">
         <div className="flex items-center gap-2">

--- a/web/src/presentation/components/plates/PlateContentTabs.tsx
+++ b/web/src/presentation/components/plates/PlateContentTabs.tsx
@@ -4,11 +4,14 @@ import { useState, useEffect, useMemo } from "react"
 import type { ComponentPropsWithoutRef } from "react"
 import { ChevronDown, ChevronRight, File, Folder } from "lucide-react"
 import type { RepoTreeEntry } from "@/src/data/repositories/githubClient"
+import { resolveRepoMarkdownHref } from "@/src/presentation/utils/readmeLinks"
 
 interface Props {
   readme: string | null
   license: string | null
   tree: RepoTreeEntry[] | null
+  repoUrl?: string | null
+  branch?: string | null
 }
 
 type Tab = "readme" | "license" | "files"
@@ -162,7 +165,7 @@ function TreeView({
   )
 }
 
-export function PlateContentTabs({ readme, license, tree }: Props) {
+export function PlateContentTabs({ readme, license, tree, repoUrl, branch }: Props) {
   const [active, setActive] = useState<Tab>("readme")
   const [MarkdownComponent, setMarkdownComponent] = useState<React.ComponentType<Record<string, unknown>> | null>(null)
   const [plugins, setPlugins] = useState<unknown[]>([])
@@ -238,37 +241,64 @@ export function PlateContentTabs({ readme, license, tree }: Props) {
 
   const content = active === "readme" ? readme : active === "license" ? license : null
 
-  const markdownComponents = {
-    pre: ({ children, ...props }: ComponentPropsWithoutRef<"pre">) => (
-      <pre
-        {...props}
-        className="my-4 overflow-x-auto border !border-border !bg-muted dark:!bg-card !p-6 text-xs leading-relaxed !text-foreground"
-      >
-        {children}
-      </pre>
-    ),
-    code: ({ inline, className, children, ...props }: ComponentPropsWithoutRef<"code"> & { inline?: boolean }) => {
-      if (inline) {
+  const branchResolved = (branch && branch.trim()) || "main"
+  const githubRepo = repoUrl?.trim() ? repoUrl : undefined
+  const sourceFileInRepo = active === "license" ? "LICENSE" : "README.md"
+
+  const markdownComponents = useMemo(
+    () => ({
+      pre: ({ children, ...props }: ComponentPropsWithoutRef<"pre">) => (
+        <pre
+          {...props}
+          className="my-4 overflow-x-auto border !border-border !bg-muted dark:!bg-card !p-6 text-xs leading-relaxed !text-foreground"
+        >
+          {children}
+        </pre>
+      ),
+      code: ({ inline, className, children, ...props }: ComponentPropsWithoutRef<"code"> & { inline?: boolean }) => {
+        if (inline) {
+          return (
+            <code
+              {...props}
+              className="rounded-none border border-border bg-muted/80 px-2 py-1 font-mono text-xs text-foreground dark:bg-card"
+            >
+              {children}
+            </code>
+          )
+        }
+
         return (
           <code
             {...props}
-            className="rounded-none border border-border bg-muted/80 px-2 py-1 font-mono text-xs text-foreground dark:bg-card"
+            className={className ? `${className} !text-foreground font-mono` : "!text-foreground font-mono"}
           >
             {children}
           </code>
         )
-      }
-
-      return (
-        <code
-          {...props}
-          className={className ? `${className} !text-foreground font-mono` : "!text-foreground font-mono"}
-        >
-          {children}
-        </code>
-      )
-    },
-  }
+      },
+      a: ({ href, children, ...props }: ComponentPropsWithoutRef<"a">) => {
+        const resolved = resolveRepoMarkdownHref(href, githubRepo, branchResolved, sourceFileInRepo)
+        const openNewTab = /^https?:\/\//i.test(resolved)
+        return (
+          <a
+            {...props}
+            href={resolved}
+            {...(openNewTab ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+          >
+            {children}
+          </a>
+        )
+      },
+      img: ({ src, alt, ...props }: ComponentPropsWithoutRef<"img">) => {
+        const srcStr = typeof src === "string" ? src : undefined
+        const resolved = srcStr
+          ? resolveRepoMarkdownHref(srcStr, githubRepo, branchResolved, sourceFileInRepo)
+          : srcStr
+        return <img {...props} src={resolved} alt={alt ?? ""} />
+      },
+    }),
+    [githubRepo, branchResolved, sourceFileInRepo],
+  )
 
   return (
     <div>

--- a/web/src/presentation/components/plates/RelatedPlates.tsx
+++ b/web/src/presentation/components/plates/RelatedPlates.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 import { Heart, Star } from "lucide-react"
 import type { Plate } from "@/src/domain/entities/Plate"
 import { formatCount } from "@/src/presentation/utils/plateUtils"
+import { PlateBadgeChips } from "@/src/presentation/components/plates/PlateBadgeChips"
 
 export function RelatedPlates({
   plates,
@@ -34,6 +35,7 @@ export function RelatedPlates({
                   {p.description}
                 </span>
               ) : null}
+              <PlateBadgeChips badges={p.badges} max={2} className="mt-1.5" />
               <span className="mt-1.5 flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
                 {p.avg_rating > 0 ? (
                   <span className="inline-flex items-center gap-1">

--- a/web/src/presentation/components/submit/SubmitRepositoryForm.tsx
+++ b/web/src/presentation/components/submit/SubmitRepositoryForm.tsx
@@ -1,11 +1,13 @@
 "use client"
 
 import { useState } from "react"
+import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useSubmitRepository } from "@/src/presentation/hooks/usePlates"
 import { useMyOrganizations } from "@/src/presentation/hooks/useOrganizations"
 import { useMe } from "@/src/presentation/hooks/useAuth"
-import { Loader2, AlertCircle, Info, Copy, Check } from "lucide-react"
+import { useConfig } from "@/src/presentation/hooks/useConfig"
+import { Loader2, AlertCircle, Copy, Check, FileCode2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { toast } from "sonner"
 
@@ -14,6 +16,8 @@ export function SubmitRepositoryForm() {
   const submit = useSubmitRepository()
   const { data: me } = useMe()
   const { data: organizations } = useMyOrganizations()
+  const { data: appConfig, isLoading: configLoading } = useConfig()
+  const plateCategories = appConfig?.plate_categories ?? []
   const [repoUrl, setRepoUrl] = useState("")
   const [branch, setBranch] = useState("main")
   const [organizationId, setOrganizationId] = useState("")
@@ -43,28 +47,149 @@ export function SubmitRepositoryForm() {
   const errorMsg = submit.error instanceof Error ? submit.error.message : null
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
-      <div className="border border-border bg-muted/30 px-4 py-3 space-y-2">
-        <div className="flex items-center gap-1.5">
-          <Info className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-          <p className="text-xs font-semibold text-foreground">Before you submit</p>
+    <form
+      onSubmit={handleSubmit}
+      className="grid grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-10 lg:items-start"
+    >
+      <div className="border border-border bg-card lg:sticky lg:top-8 self-start">
+        <div className="border-b border-border bg-muted/20 px-4 py-3 flex items-start gap-2.5">
+          <FileCode2 className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
+          <div>
+            <h2 className="text-sm font-semibold text-foreground">Before you submit</h2>
+            <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
+              Add <code className="font-mono bg-muted px-1 py-0.5">kikplate.yaml</code> at the repository root.{" "}
+              <Link
+                href="/docs?doc=how-it-works"
+                className="font-medium text-foreground underline underline-offset-2 hover:text-muted-foreground"
+              >
+                How it works
+              </Link>
+            </p>
+          </div>
         </div>
-        <ul className="text-xs text-muted-foreground space-y-1 pl-5">
-          <li>· The repository must be public</li>
-          <li>
-            · It must contain a{" "}
-            <code className="font-mono bg-muted px-1 py-0.5">kikplate.yaml</code>{" "}
-            at the root
-          </li>
-          <li>
-            · The <code className="font-mono bg-muted px-1 py-0.5">owner</code> field in that
-            file must match: <span className="font-mono text-foreground font-medium">{ownerHint}</span>{" "}
-            ({isPersonalSubmission ? "personal submit uses your username" : "org submit uses organization name"})
-          </li>
-        </ul>
+
+        <div className="px-4 py-4 space-y-5 text-xs text-muted-foreground leading-relaxed">
+          <div>
+            <p className="font-semibold text-foreground mb-1.5">Repository</p>
+            <ul className="list-disc pl-4 space-y-1 mb-3">
+              <li>The repository must be public.</li>
+              <li>
+                It must include <code className="font-mono bg-muted px-1 py-0.5">kikplate.yaml</code> at the root on
+                the branch you enter below.
+              </li>
+            </ul>
+
+            <p className="font-semibold text-foreground mb-2 text-[11px] uppercase tracking-wide">
+              Personal or organization
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="rounded border border-border/80 bg-muted/10 px-3 py-2.5 space-y-1">
+                <p className="text-xs font-semibold text-foreground">Personal</p>
+                <p className="text-[11px] text-muted-foreground leading-relaxed">
+                  Under Repository details, leave <span className="text-foreground font-medium">Personal</span>. The
+                  plate is registered on <span className="text-foreground font-medium">your user account</span> only.
+                  In <code className="font-mono bg-muted px-1 py-0.5">kikplate.yaml</code>, set{" "}
+                  <code className="font-mono bg-muted px-1 py-0.5">owner</code> to your Kikplate username
+                  {me?.username ? (
+                    <> (<span className="font-mono text-foreground">{me.username}</span>)</>
+                  ) : (
+                    <> (the username on your profile)</>
+                  )}.
+                </p>
+              </div>
+              <div className="rounded border border-border/80 bg-muted/10 px-3 py-2.5 space-y-1">
+                <p className="text-xs font-semibold text-foreground">Organization</p>
+                <p className="text-[11px] text-muted-foreground leading-relaxed">
+                  Under Repository details, choose an <span className="text-foreground font-medium">organization you own</span>.
+                  The plate is registered <span className="text-foreground font-medium">under that organization</span> (not
+                  only on your user). In <code className="font-mono bg-muted px-1 py-0.5">kikplate.yaml</code>, set{" "}
+                  <code className="font-mono bg-muted px-1 py-0.5">owner</code> to the{" "}
+                  <span className="text-foreground font-medium">organization&apos;s exact name</span>—not your personal
+                  username.
+                </p>
+              </div>
+            </div>
+
+            <p className="mt-3 rounded border border-border/70 bg-muted/15 px-3 py-2 text-[11px] leading-relaxed">
+              <span className="font-medium text-foreground">For this submit: </span>
+              {isPersonalSubmission ? (
+                <>
+                  You have <span className="text-foreground font-medium">Personal</span> selected →{" "}
+                  <code className="font-mono bg-muted px-1 py-0.5">owner</code> must be{" "}
+                  <span className="font-mono text-foreground font-medium">{ownerHint}</span>.
+                </>
+              ) : (
+                <>
+                  You have <span className="text-foreground font-medium">{selectedOrganization?.name}</span> selected →
+                  the plate goes to that org → <code className="font-mono bg-muted px-1 py-0.5">owner</code> must be{" "}
+                  <span className="font-mono text-foreground font-medium">{ownerHint}</span> (org name, not your username).
+                </>
+              )}
+            </p>
+          </div>
+
+          <div>
+            <p className="font-semibold text-foreground mb-1.5">Manifest fields</p>
+            <ul className="list-disc pl-4 space-y-1">
+              <li>
+                <span className="text-foreground">Required:</span>{" "}
+                <code className="font-mono bg-muted px-1 py-0.5">name</code> (plate title, used for the slug),{" "}
+                <code className="font-mono bg-muted px-1 py-0.5">owner</code> (must match the value above).
+              </li>
+              <li>
+                <span className="text-foreground">Optional:</span>{" "}
+                <code className="font-mono bg-muted px-1 py-0.5">description</code>,{" "}
+                <code className="font-mono bg-muted px-1 py-0.5">category</code> (must be one of the slugs below;
+                matching is case-insensitive; anything else or empty becomes{" "}
+                <code className="font-mono bg-muted px-1 py-0.5">other</code>),{" "}
+                <code className="font-mono bg-muted px-1 py-0.5">tags</code>.
+              </li>
+              <li>
+                <span className="text-foreground">After submit:</span> add{" "}
+                <code className="font-mono bg-muted px-1 py-0.5">verification_token</code> from your account, push,
+                then verify so the plate can go public. Sync keeps re-reading this file.
+              </li>
+            </ul>
+
+            <div className="mt-3 rounded border border-border/70 bg-muted/10 px-3 py-2.5">
+              <p className="text-[11px] font-semibold text-foreground mb-2">Allowed category slugs</p>
+              {configLoading ? (
+                <p className="text-[11px] text-muted-foreground italic">Loading…</p>
+              ) : plateCategories.length === 0 ? (
+                <p className="text-[11px] text-muted-foreground italic">None returned.</p>
+              ) : (
+                <ul className="flex flex-wrap gap-1.5">
+                  {plateCategories.map((c) => (
+                    <li
+                      key={c.slug}
+                      title={c.label ? `${c.label}: ${c.description}` : c.description}
+                      className="border border-border bg-background px-2 py-0.5 font-mono text-[11px] text-foreground"
+                    >
+                      {c.slug}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <p className="font-semibold text-foreground mb-1.5">Minimal example</p>
+            <pre className="border border-border bg-muted/20 p-3 font-mono text-[11px] text-foreground overflow-x-auto leading-snug">
+{`name: My Starter
+owner: your-username
+description: Short summary
+category: backend
+tags:
+  - golang
+  - docker`}
+            </pre>
+          </div>
+        </div>
       </div>
 
-      <div className="space-y-4">
+      <div className="min-w-0 space-y-6">
+        <div className="space-y-4">
         <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
           Repository details
         </p>
@@ -116,7 +241,7 @@ export function SubmitRepositoryForm() {
             </p>
           )}
         </div>
-      </div>
+        </div>
 
       {errorMsg && (
         <div className="border border-destructive/40 bg-destructive/5 px-4 py-3 space-y-2">
@@ -184,15 +309,16 @@ export function SubmitRepositoryForm() {
         </div>
       )}
 
-      <div className="border-t border-border pt-5">
-        <Button
-          type="submit"
-          disabled={submit.isPending || !repoUrl}
-          className="gap-2"
-        >
-          {submit.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
-          Submit repository plate
-        </Button>
+        <div className="border-t border-border pt-5">
+          <Button
+            type="submit"
+            disabled={submit.isPending || !repoUrl}
+            className="gap-2"
+          >
+            {submit.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+            Submit repository plate
+          </Button>
+        </div>
       </div>
     </form>
   )

--- a/web/src/presentation/utils/plateCategoryIcons.ts
+++ b/web/src/presentation/utils/plateCategoryIcons.ts
@@ -1,0 +1,40 @@
+import {
+  BookOpen,
+  Bot,
+  Cloud,
+  Cpu,
+  Database,
+  Gamepad2,
+  Globe,
+  Layers,
+  MoreHorizontal,
+  Package,
+  Server,
+  Shield,
+  Smartphone,
+  Terminal,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react"
+
+const plateCategoryIconMap: Record<string, LucideIcon> = {
+  "server": Server,
+  "globe": Globe,
+  "layers": Layers,
+  "smartphone": Smartphone,
+  "terminal": Terminal,
+  "wrench": Wrench,
+  "package": Package,
+  "database": Database,
+  "cloud": Cloud,
+  "shield": Shield,
+  "cpu": Cpu,
+  "gamepad-2": Gamepad2,
+  "book-open": BookOpen,
+  "bot": Bot,
+  "more-horizontal": MoreHorizontal,
+}
+
+export function getPlateCategoryIcon(iconKey: string): LucideIcon {
+  return plateCategoryIconMap[iconKey] ?? MoreHorizontal
+}

--- a/web/src/presentation/utils/readmeLinks.ts
+++ b/web/src/presentation/utils/readmeLinks.ts
@@ -1,0 +1,40 @@
+import { repoToPath } from "@/src/data/repositories/githubClient"
+
+function encodeRepoFilePath(path: string): string {
+  return path
+    .split("/")
+    .filter(Boolean)
+    .map((s) => encodeURIComponent(s))
+    .join("/")
+}
+
+export function resolveRepoMarkdownHref(
+  href: string | undefined,
+  repoUrl: string | undefined,
+  branch: string | undefined,
+  sourceFileInRepo: string
+): string {
+  if (href == null || href === "") return "#"
+  const trimmed = href.trim()
+  if (trimmed.startsWith("#")) return trimmed
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return trimmed
+  if (trimmed.startsWith("//")) return `https:${trimmed}`
+  if (!repoUrl || !branch) return trimmed
+
+  const repoPath = repoToPath(repoUrl)
+  const branchEnc = encodeURIComponent(branch)
+
+  if (trimmed.startsWith("/") && !trimmed.startsWith("//")) {
+    const rel = trimmed.replace(/^\/+/, "")
+    if (!rel) return trimmed
+    return `https://github.com/${repoPath}/blob/${branchEnc}/${encodeRepoFilePath(rel)}`
+  }
+
+  const base = `https://github.com/${repoPath}/blob/${branchEnc}/${sourceFileInRepo}`
+  try {
+    return new URL(trimmed, base).href
+  } catch {
+    return trimmed
+  }
+}
+


### PR DESCRIPTION
- Restrict plate categories to config (normalize unknown to other); sync,
  submit, filters, and stats use EffectivePlateCategories; expose slugs via
  GET /config; CategoriesGrid and Helm/K8s/config YAML updated.
- Submit flow: merged guidance + two-column layout; personal vs org copy;
  allowed category slugs from useConfig; removed duplicate rules card.
- Docs: configuration (plate_categories, public config); how-it-works
  manifest table.
- Resolve relative README/LICENSE links and images to GitHub blob URLs on
  plate detail tabs.
- Preload Badges.Badge on plate List; shared PlateBadgeChips on cards,
  featured strip, and related plates.