### PR TITLE
feat(cli): add localhost callback support for SSO login

### DIFF
--- a/api/handler/handlers/auth_handler.go
+++ b/api/handler/handlers/auth_handler.go
@@ -1,8 +1,12 @@
 package handlers
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/kickplate/api/handler/middleware"
@@ -93,6 +97,26 @@ func (h AuthHandler) LoginLocal(w http.ResponseWriter, r *http.Request) {
 
 func (h AuthHandler) OAuthRedirect(w http.ResponseWriter, r *http.Request) {
 	provider := chi.URLParam(r, "provider")
+	h.logger.Infof("=== OAuthRedirect called for provider: %s ===", provider)
+	h.logger.Infof("Raw query: %s", r.URL.RawQuery)
+
+	cliRedirectURI := normalizeCLIRedirectURI(r.URL.Query().Get("redirect_uri"))
+	if cliRedirectURI == "" {
+		rawCliCallback := r.URL.Query().Get("cli_callback")
+		if rawCliCallback != "" {
+			preview := rawCliCallback
+			if len(preview) > 50 {
+				preview = preview[:50]
+			}
+			h.logger.Infof("received cli_callback: %s", preview)
+		}
+		cliRedirectURI = normalizeCLIRedirectURI(decodeCLICallback(rawCliCallback))
+		if cliRedirectURI != "" {
+			h.logger.Infof("decoded and normalized CLI redirect URI: %s", cliRedirectURI)
+		} else if rawCliCallback != "" {
+			h.logger.Warnf("failed to decode/normalize cli_callback")
+		}
+	}
 
 	result, err := h.authService.OAuthRedirect(r.Context(), auth.OAuthRedirectInput{
 		Provider: provider,
@@ -111,6 +135,28 @@ func (h AuthHandler) OAuthRedirect(w http.ResponseWriter, r *http.Request) {
 		Path:     "/",
 		SameSite: http.SameSiteLaxMode,
 	})
+
+	if cliRedirectURI != "" {
+		h.logger.Infof("setting oauth_redirect_uri cookie to: %s", cliRedirectURI)
+		http.SetCookie(w, &http.Cookie{
+			Name:     "oauth_redirect_uri",
+			Value:    url.QueryEscape(cliRedirectURI),
+			MaxAge:   300,
+			HttpOnly: true,
+			Path:     "/",
+			SameSite: http.SameSiteLaxMode,
+		})
+	} else {
+		h.logger.Warnf("no CLI redirect URI found, using default frontend callback")
+		http.SetCookie(w, &http.Cookie{
+			Name:     "oauth_redirect_uri",
+			Value:    "",
+			MaxAge:   -1,
+			HttpOnly: true,
+			Path:     "/",
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
 
 	http.Redirect(w, r, result.URL, http.StatusTemporaryRedirect)
 }
@@ -131,6 +177,22 @@ func (h AuthHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	frontendBase := h.env.FrontendURL
+	redirectBase := strings.TrimRight(frontendBase, "/") + "/auth/callback"
+	if redirectCookie, err := r.Cookie("oauth_redirect_uri"); err == nil {
+		h.logger.Infof("found oauth_redirect_uri cookie: %s", redirectCookie.Value)
+		if decoded, decErr := url.QueryUnescape(redirectCookie.Value); decErr == nil {
+			if normalized := normalizeCLIRedirectURI(decoded); normalized != "" {
+				h.logger.Infof("using CLI redirect: %s", normalized)
+				redirectBase = normalized
+			} else {
+				h.logger.Warnf("failed to normalize CLI redirect from cookie: %s", decoded)
+			}
+		} else {
+			h.logger.Warnf("failed to unescape cookie value: %v", decErr)
+		}
+	} else {
+		h.logger.Warnf("no oauth_redirect_uri cookie found, using default: %s", redirectBase)
+	}
 
 	result, err := h.authService.OAuthCallback(r.Context(), auth.OAuthCallbackInput{
 		Provider: provider,
@@ -139,11 +201,67 @@ func (h AuthHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		h.logger.Errorf("oauth callback failed: %v", err)
-		http.Redirect(w, r, frontendBase+"/login?error=oauth_failed", http.StatusTemporaryRedirect)
+		http.Redirect(w, r, appendQueryParam(redirectBase, "error", "oauth_failed"), http.StatusTemporaryRedirect)
 		return
 	}
 
-	http.Redirect(w, r, frontendBase+"/auth/callback?token="+result.Token, http.StatusTemporaryRedirect)
+	http.Redirect(w, r, appendQueryParam(redirectBase, "token", result.Token), http.StatusTemporaryRedirect)
+}
+
+func normalizeCLIRedirectURI(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return ""
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return ""
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	if host != "127.0.0.1" && host != "localhost" {
+		return ""
+	}
+
+	if parsed.Path == "" {
+		parsed.Path = "/"
+	}
+
+	return parsed.String()
+}
+
+func appendQueryParam(base, key, value string) string {
+	u, err := url.Parse(base)
+	if err != nil {
+		if strings.Contains(base, "?") {
+			return fmt.Sprintf("%s&%s=%s", base, key, url.QueryEscape(value))
+		}
+		return fmt.Sprintf("%s?%s=%s", base, key, url.QueryEscape(value))
+	}
+	q := u.Query()
+	q.Set(key, value)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func decodeCLICallback(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	decoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return ""
+	}
+
+	return string(decoded)
 }
 
 func (h AuthHandler) Me(w http.ResponseWriter, r *http.Request) {

--- a/cli/cmd/client.go
+++ b/cli/cmd/client.go
@@ -100,14 +100,37 @@ func decodeJSON(resp *http.Response, target any) error {
 
 func decodeJSONStatus(resp *http.Response, expect int, target any) error {
 	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
 	if resp.StatusCode == http.StatusUnauthorized {
 		return fmt.Errorf("unauthorized — run 'kikplate login' first")
 	}
 	if resp.StatusCode != expect {
-		body, _ := io.ReadAll(resp.Body)
+		if looksLikeHTML(resp, body) {
+			return fmt.Errorf("server returned HTML instead of JSON; check server.address points to the API base URL (for kikplate.dev use https://kikplate.dev/api)")
+		}
 		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
 	}
-	return json.NewDecoder(resp.Body).Decode(target)
+	if len(body) == 0 {
+		return nil
+	}
+	if looksLikeHTML(resp, body) {
+		return fmt.Errorf("server returned HTML instead of JSON; check server.address points to the API base URL (for kikplate.dev use https://kikplate.dev/api)")
+	}
+	if err := json.Unmarshal(body, target); err != nil {
+		return fmt.Errorf("cannot parse server response as JSON: %w", err)
+	}
+	return nil
+}
+
+func looksLikeHTML(resp *http.Response, body []byte) bool {
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	if strings.Contains(contentType, "text/html") {
+		return true
+	}
+
+	trimmed := strings.TrimSpace(strings.ToLower(string(body)))
+	return strings.HasPrefix(trimmed, "<!doctype html") || strings.HasPrefix(trimmed, "<html")
 }
 
 func (s *Session) GetJSON(path string, query url.Values, target any) error {
@@ -138,6 +161,9 @@ func (s *Session) FetchPlateBySlug(slug string) (*LocalPlate, error) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if looksLikeHTML(resp, body) {
+			return nil, fmt.Errorf("server returned HTML instead of JSON; check server.address points to the API base URL (for kikplate.dev use https://kikplate.dev/api)")
+		}
 		return nil, fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -147,7 +173,11 @@ func (s *Session) FetchPlateBySlug(slug string) (*LocalPlate, error) {
 		Description string  `json:"description"`
 		RepoURL     *string `json:"repo_url"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&plate); err != nil {
+	body, _ := io.ReadAll(resp.Body)
+	if looksLikeHTML(resp, body) {
+		return nil, fmt.Errorf("server returned HTML instead of JSON; check server.address points to the API base URL (for kikplate.dev use https://kikplate.dev/api)")
+	}
+	if err := json.Unmarshal(body, &plate); err != nil {
 		return nil, fmt.Errorf("cannot parse server response: %w", err)
 	}
 

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -1,10 +1,20 @@
 package cmd
 
 import (
+	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -53,6 +63,76 @@ var loginCmd = &cobra.Command{
 			return fmt.Errorf("cannot save config: %w", err)
 		}
 		fmt.Println("Login successful. Token saved.")
+		return nil
+	},
+}
+
+var loginSSOCmd = &cobra.Command{
+	Use:   "sso <provider>",
+	Short: "Authenticate with a configured SSO provider",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		s, err := NewSession(cmd)
+		if err != nil {
+			return err
+		}
+
+		var providersResponse struct {
+			Providers []string `json:"providers"`
+		}
+		if err := s.GetJSON("/auth/providers", nil, &providersResponse); err != nil {
+			return fmt.Errorf("cannot fetch SSO providers: %w", err)
+		}
+
+		providers := providersResponse.Providers
+		sort.Strings(providers)
+		if len(providers) == 0 {
+			return fmt.Errorf("no SSO providers are configured on this server")
+		}
+
+		if len(args) == 0 {
+			return fmt.Errorf("provider is required; available providers: %s", strings.Join(providers, ", "))
+		}
+
+		provider, ok := resolveProvider(args[0], providers)
+		if !ok {
+			return fmt.Errorf("unknown provider %q; available providers: %s", args[0], strings.Join(providers, ", "))
+		}
+
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return fmt.Errorf("cannot start local callback listener: %w", err)
+		}
+
+		callbackURL := fmt.Sprintf("http://%s/callback", listener.Addr().String())
+		authURL, err := buildSSOLoginURL(s.Addr(), provider, callbackURL)
+		if err != nil {
+			_ = listener.Close()
+			return err
+		}
+
+		fmt.Printf("Callback URL: %s\n", callbackURL)
+		fmt.Printf("Auth URL: %s\n", authURL)
+		fmt.Printf("Opening browser for %s SSO login...\n", provider)
+		if err := openBrowser(authURL); err != nil {
+			fmt.Printf("Could not open browser automatically. Open this URL manually:\n%s\n", authURL)
+		}
+		fmt.Println("Waiting for callback...")
+
+		token, err := awaitSSOToken(listener, 3*time.Minute)
+		if err != nil {
+			return err
+		}
+		if token == "" {
+			return fmt.Errorf("received empty token from SSO callback")
+		}
+
+		s.Config.Auth.Token = token
+		if err := s.SaveConfig(); err != nil {
+			return fmt.Errorf("cannot save config: %w", err)
+		}
+
+		fmt.Println("SSO login successful. Token saved.")
 		return nil
 	},
 }
@@ -116,8 +196,110 @@ var whoamiCmd = &cobra.Command{
 func init() {
 	loginCmd.Flags().String("email", "", "Email address")
 	loginCmd.Flags().String("password", "", "Password")
+	loginCmd.AddCommand(loginSSOCmd)
 
 	rootCmd.AddCommand(loginCmd)
 	rootCmd.AddCommand(logoutCmd)
 	rootCmd.AddCommand(whoamiCmd)
+}
+
+func resolveProvider(input string, providers []string) (string, bool) {
+	for _, p := range providers {
+		if strings.EqualFold(input, p) {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+func buildSSOLoginURL(serverAddr, provider, callbackURL string) (string, error) {
+	base, err := url.Parse(strings.TrimRight(serverAddr, "/"))
+	if err != nil {
+		return "", fmt.Errorf("invalid server address %q: %w", serverAddr, err)
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + "/auth/" + provider + "/redirect"
+	q := base.Query()
+	q.Set("cli_callback", base64.RawURLEncoding.EncodeToString([]byte(callbackURL)))
+	base.RawQuery = q.Encode()
+	return base.String(), nil
+}
+
+func awaitSSOToken(listener net.Listener, timeout time.Duration) (string, error) {
+	tokenCh := make(chan string, 1)
+	flowErrCh := make(chan error, 1)
+	serverErrCh := make(chan error, 1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimSpace(r.URL.Query().Get("token"))
+		errParam := strings.TrimSpace(r.URL.Query().Get("error"))
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if errParam != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("<html><body><h3>SSO login failed</h3><p>You can close this window and retry in the terminal.</p></body></html>"))
+			select {
+			case flowErrCh <- fmt.Errorf("sso login failed: %s", errParam):
+			default:
+			}
+			return
+		}
+
+		if token == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("<html><body><h3>Missing token</h3><p>No token received from server. This usually means the OAuth callback URL wasn't recognized. Check terminal for details and try again.</p></body></html>"))
+			select {
+			case flowErrCh <- fmt.Errorf("missing token in SSO callback"):
+			default:
+			}
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html><body><h3>Login successful</h3><p style='color:green'><strong>✓ Token received!</strong></p><p>You can close this window and return to the terminal.</p></body></html>"))
+		select {
+		case tokenCh <- token:
+		default:
+		}
+	})
+
+	server := &http.Server{Handler: mux}
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErrCh <- err
+		}
+	}()
+
+	select {
+	case token := <-tokenCh:
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+		return token, nil
+	case err := <-flowErrCh:
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+		return "", err
+	case err := <-serverErrCh:
+		return "", fmt.Errorf("local callback server failed: %w", err)
+	case <-time.After(timeout):
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+		return "", fmt.Errorf("timeout waiting for SSO callback")
+	}
+}
+
+func openBrowser(targetURL string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", targetURL)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", targetURL)
+	default:
+		cmd = exec.Command("xdg-open", targetURL)
+	}
+	return cmd.Start()
 }


### PR DESCRIPTION
Add browser-based SSO login to the CLI and teach the API auth handler to redirect OAuth callbacks back to a localhost listener when a CLI callback is provided. Also improve CLI HTTP error handling so frontend HTML responses are surfaced with a clearer API base URL hint.