### PR TITLE
Feat/unify manifest plate yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
 
 | Topic | Description |
 |-------|-------------|
-| **Templates as code** | Every template ("plate") is a public GitHub repository containing a `kikplate.yaml` manifest. There is nothing to upload — the source of truth is always the repository. |
-| **Verification workflow** | Submitting a plate issues a one-time token. Placing that token in `kikplate.yaml` and calling `verify` proves ownership and moves the plate to the approved state. |
-| **Continuous sync** | The background sync worker periodically re-reads each approved plate's `kikplate.yaml`, updating metadata and catching drift or revocation automatically. |
+| **Templates as code** | Every template ("plate") is a public GitHub repository containing a `plate.yaml` manifest. There is nothing to upload — the source of truth is always the repository. |
+| **Verification workflow** | Submitting a plate issues a one-time token. Placing that token in `plate.yaml` and calling `verify` proves ownership and moves the plate to the approved state. |
+| **Continuous sync** | The background sync worker periodically re-reads each approved plate's `plate.yaml`, updating metadata and catching drift or revocation automatically. |
 | **Organizations** | Plates can be scoped to an organization, enabling teams and companies to maintain shared template catalogs under a single namespace. |
 | **Badges** | Admins award badges (community, verified, official, sponsored) to signal quality and curation level. |
 | **CLI** | The `kikplate` CLI handles authentication, searching, describing, and scaffolding templates without touching a browser. |
@@ -110,7 +110,7 @@ kikplate search --category backend
 | Document | Description |
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Prerequisites, local setup, dev workflow, running tests |
-| [How It Works](docs/how-it-works.md) | Core concepts: plates, kikplate.yaml, verification lifecycle, sync, badges |
+| [How It Works](docs/how-it-works.md) | Core concepts: plates, plate.yaml, verification lifecycle, sync, badges |
 | [Architecture](docs/architecture.md) | Component map, layers, HTTP surface, DI modules, data flow diagrams |
 | [Database](docs/database.md) | Schema reference, table definitions, entity relationships |
 | [Configuration](docs/configuration.md) | All config file keys and environment variable overrides |

--- a/api/command/sync.go
+++ b/api/command/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -149,7 +150,7 @@ func syncOnePlate(
 		return
 	}
 
-	manifest, _, err := fetchKickplateYAML(*plate.RepoURL, *plate.Branch)
+	manifest, _, err := fetchPlateManifestYAML(*plate.RepoURL, *plate.Branch)
 	if err != nil {
 		failed := model.SyncStatusFailed
 		errText := err.Error()
@@ -268,7 +269,7 @@ func syncOnePlate(
 	logger.Infof("sync: plate %s status=%s next=%s", plate.ID, syncStatus, nextSync.Format(time.RFC3339))
 }
 
-type syncKickplateYAML struct {
+type syncPlateManifestYAML struct {
 	Owner             string           `yaml:"owner"`
 	Name              string           `yaml:"name"`
 	Description       string           `yaml:"description"`
@@ -285,7 +286,7 @@ func syncPlateManifest(
 	plateTagRepo repository.PlateTagRepository,
 	env lib.Env,
 	plate *model.Plate,
-	manifest *syncKickplateYAML,
+	manifest *syncPlateManifestYAML,
 	metadataJSON []byte,
 ) error {
 	plate.Name = manifest.Name
@@ -336,8 +337,36 @@ func normalizedManifestTags(tags []string) []string {
 	return result
 }
 
-func fetchKickplateYAML(repoURL, branch string) (*syncKickplateYAML, []byte, error) {
-	apiURL := repoURLToContentsURL(repoURL, branch)
+func fetchPlateManifestYAML(repoURL, branch string) (*syncPlateManifestYAML, []byte, error) {
+	manifest, raw, err := fetchManifestFileYAML(repoURL, branch, "plate.yaml")
+	if err == nil && strings.TrimSpace(manifest.Owner) != "" {
+		return manifest, raw, nil
+	}
+	if err != nil && !errors.Is(err, ErrSyncMissingManifest) {
+		return nil, nil, err
+	}
+
+	legacyManifest, legacyRaw, legacyErr := fetchManifestFileYAML(repoURL, branch, "kikplate.yaml")
+	if legacyErr != nil {
+		if err == nil {
+			return nil, nil, ErrSyncMissingManifest
+		}
+		if errors.Is(err, ErrSyncMissingManifest) && errors.Is(legacyErr, ErrSyncMissingManifest) {
+			return nil, nil, ErrSyncMissingManifest
+		}
+		return nil, nil, legacyErr
+	}
+	if strings.TrimSpace(legacyManifest.Owner) == "" {
+		return nil, nil, ErrSyncMissingManifest
+	}
+
+	return legacyManifest, legacyRaw, nil
+}
+
+var ErrSyncMissingManifest = errors.New("manifest not found")
+
+func fetchManifestFileYAML(repoURL, branch, filename string) (*syncPlateManifestYAML, []byte, error) {
+	apiURL := repoURLToContentsURL(repoURL, branch, filename)
 	client := &http.Client{Timeout: 15 * time.Second}
 	resp, err := client.Get(apiURL)
 	if err != nil {
@@ -346,7 +375,7 @@ func fetchKickplateYAML(repoURL, branch string) (*syncKickplateYAML, []byte, err
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, nil, fmt.Errorf("kikplate.yaml not found")
+		return nil, nil, ErrSyncMissingManifest
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, nil, fmt.Errorf("fetch failed with status %d", resp.StatusCode)
@@ -370,16 +399,16 @@ func fetchKickplateYAML(repoURL, branch string) (*syncKickplateYAML, []byte, err
 		raw = []byte(ghResp.Content)
 	}
 
-	var kp syncKickplateYAML
-	if err := yaml.Unmarshal(raw, &kp); err != nil {
-		return nil, nil, fmt.Errorf("invalid kickplate.yaml")
+	var manifest syncPlateManifestYAML
+	if err := yaml.Unmarshal(raw, &manifest); err != nil {
+		return nil, nil, fmt.Errorf("invalid manifest yaml")
 	}
 
-	return &kp, raw, nil
+	return &manifest, raw, nil
 }
 
-func repoURLToContentsURL(repoURL, branch string) string {
-	return fmt.Sprintf("https://api.github.com/repos/%s/contents/kikplate.yaml?ref=%s", extractRepoPath(repoURL), branch)
+func repoURLToContentsURL(repoURL, branch, filename string) string {
+	return fmt.Sprintf("https://api.github.com/repos/%s/contents/%s?ref=%s", extractRepoPath(repoURL), filename, branch)
 }
 
 func extractRepoPath(repoURL string) string {

--- a/api/service/plate/errors.go
+++ b/api/service/plate/errors.go
@@ -12,7 +12,7 @@ var (
 	ErrOrganizationRequired      = errors.New("organization is required")
 	ErrNoUsername                = errors.New("repository plates require a username — go to Account settings to set one before submitting")
 	ErrOwnerMismatch             = errors.New("owner field does not match the expected owner (username for personal, organization name for org submissions)")
-	ErrMissingYAML               = errors.New("kikplate.yaml not found in repository")
+	ErrMissingYAML               = errors.New("manifest not found in repository (expected plate.yaml or kikplate.yaml)")
 	ErrFetchFailed               = errors.New("failed to fetch repository")
 	ErrAlreadyReviewed           = errors.New("you have already reviewed this plate")
 	ErrCannotReviewOwn           = errors.New("you cannot review your own plate")

--- a/api/service/plate/github_yaml.go
+++ b/api/service/plate/github_yaml.go
@@ -3,6 +3,7 @@ package plate
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,7 +19,35 @@ func (s *plateService) fetchKickplateYAML(repoURL, branch string) (*KickplateYAM
 }
 
 func (s *plateService) fetchKickplateYAMLWithOptions(repoURL, branch string, forceRefresh bool) (*KickplateYAML, error) {
-	apiURL := repoURLToContentsURL(repoURL, branch)
+	manifest, err := s.fetchManifestYAML(repoURL, branch, "plate.yaml", forceRefresh)
+	if err == nil && strings.TrimSpace(manifest.Owner) != "" {
+		return manifest, nil
+	}
+
+	if err != nil && !errors.Is(err, ErrMissingYAML) {
+		return nil, err
+	}
+
+	legacy, legacyErr := s.fetchManifestYAML(repoURL, branch, "kikplate.yaml", forceRefresh)
+	if legacyErr != nil {
+		if err == nil {
+			return nil, ErrMissingYAML
+		}
+		if errors.Is(err, ErrMissingYAML) && errors.Is(legacyErr, ErrMissingYAML) {
+			return nil, ErrMissingYAML
+		}
+		return nil, legacyErr
+	}
+
+	if strings.TrimSpace(legacy.Owner) == "" {
+		return nil, ErrMissingYAML
+	}
+
+	return legacy, nil
+}
+
+func (s *plateService) fetchManifestYAML(repoURL, branch, filename string, forceRefresh bool) (*KickplateYAML, error) {
+	apiURL := repoURLToContentsURL(repoURL, branch, filename)
 	if forceRefresh {
 		apiURL = fmt.Sprintf("%s&_nonce=%d", apiURL, time.Now().UnixNano())
 	}
@@ -65,20 +94,17 @@ func (s *plateService) fetchKickplateYAMLWithOptions(repoURL, branch string, for
 		raw = []byte(ghResp.Content)
 	}
 
-	var kp KickplateYAML
-	if err := yaml.Unmarshal(raw, &kp); err != nil {
+	var manifest KickplateYAML
+	if err := yaml.Unmarshal(raw, &manifest); err != nil {
 		return nil, ErrFetchFailed
 	}
-	if kp.Owner == "" {
-		return nil, ErrMissingYAML
-	}
 
-	return &kp, nil
+	return &manifest, nil
 }
 
-func repoURLToContentsURL(repoURL, branch string) string {
-	return fmt.Sprintf("https://api.github.com/repos/%s/contents/kikplate.yaml?ref=%s",
-		extractRepoPath(repoURL), url.QueryEscape(strings.TrimSpace(branch)))
+func repoURLToContentsURL(repoURL, branch, filename string) string {
+	return fmt.Sprintf("https://api.github.com/repos/%s/contents/%s?ref=%s",
+		extractRepoPath(repoURL), filename, url.QueryEscape(strings.TrimSpace(branch)))
 }
 
 func extractRepoPath(repoURL string) string {

--- a/api/service/plate/service.go
+++ b/api/service/plate/service.go
@@ -7,7 +7,7 @@ import (
 	"gorm.io/gorm"
 )
 
-type KickplateYAML struct {
+type RepositoryManifestYAML struct {
 	Owner             string           `yaml:"owner"`
 	Name              string           `yaml:"name"`
 	Description       string           `yaml:"description"`
@@ -17,6 +17,8 @@ type KickplateYAML struct {
 	Variables         []map[string]any `yaml:"variables"`
 	Dependencies      []map[string]any `yaml:"dependencies"`
 }
+
+type KickplateYAML = RepositoryManifestYAML
 
 type plateService struct {
 	db           *gorm.DB

--- a/cli/cmd/scaf.go
+++ b/cli/cmd/scaf.go
@@ -182,12 +182,14 @@ func stampReadme(dir string, plate *LocalPlate) {
 }
 
 func cleanKikplateYaml(dir string) {
-	path := filepath.Join(dir, "kikplate.yaml")
-	if _, err := os.Stat(path); err == nil {
-		if err := os.Remove(path); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: could not remove kikplate.yaml: %v\n", err)
-		} else {
-			fmt.Println("Removed kikplate.yaml")
+	for _, filename := range []string{"plate.yaml", "kikplate.yaml"} {
+		path := filepath.Join(dir, filename)
+		if _, err := os.Stat(path); err == nil {
+			if err := os.Remove(path); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not remove %s: %v\n", filename, err)
+			} else {
+				fmt.Printf("Removed %s\n", filename)
+			}
 		}
 	}
 }

--- a/cli/cmd/submit.go
+++ b/cli/cmd/submit.go
@@ -11,7 +11,7 @@ var submitCmd = &cobra.Command{
 	Use:   "submit [repo-url]",
 	Short: "Submit a repository as a new plate",
 	Long: `Submit a GitHub repository to the Kikplate server.
-The repository must contain a kickplate.yaml manifest.
+The repository must contain a plate.yaml manifest.
 After submission the plate will be in "pending" status until verified.`,
 	Example: `  kikplate submit https://github.com/org/repo
   kikplate submit https://github.com/org/repo --branch develop
@@ -47,7 +47,7 @@ After submission the plate will be in "pending" status until verified.`,
 		fmt.Printf("  Status:   %s\n", plate.Status)
 		if plate.VerificationToken != nil {
 			fmt.Printf("\nVerification token: %s\n", *plate.VerificationToken)
-			fmt.Println("Add this token to your kickplate.yaml as 'verification_token',")
+			fmt.Println("Add this token to your plate.yaml as 'verification_token',")
 			fmt.Println("then run: kikplate verify " + plate.Slug)
 		}
 		return nil

--- a/cli/cmd/verify.go
+++ b/cli/cmd/verify.go
@@ -10,9 +10,9 @@ import (
 var verifyCmd = &cobra.Command{
 	Use:   "verify [slug]",
 	Short: "Verify a submitted plate",
-	Long: `Verify a plate by checking its kickplate.yaml verification token.
+	Long: `Verify a plate by checking its plate.yaml verification token.
 The plate must have been submitted first and the verification_token
-must be present in the repository's kickplate.yaml file.
+must be present in the repository's plate.yaml file.
 On success the plate becomes approved, public, and verified.`,
 	Example: `  kikplate verify myorg/my-template`,
 	Args:    cobra.ExactArgs(1),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,7 @@ All routes are registered in `api/handler/routes/module.go`. The base URL for al
 
 ## Plate Lifecycle
 
-A plate is the core entity in Kikplate. Every plate is backed by a public GitHub repository that contains a `kikplate.yaml` manifest at its root.
+A plate is the core entity in Kikplate. Every plate is backed by a public GitHub repository that contains a `plate.yaml` manifest at its root.
 
 ```mermaid
 stateDiagram-v2
@@ -161,9 +161,9 @@ stateDiagram-v2
 Submission flow:
 
 1. User submits a repository URL via `POST /plates/repository`.
-2. The service fetches `kikplate.yaml` from the repository and validates the declared owner.
+2. The service fetches `plate.yaml` from the repository and validates the declared owner.
 3. A plate record is created with `status=pending`, `visibility=private`, and a generated `verification_token`.
-4. The user adds that token to `kikplate.yaml` in their repository and calls `POST /plates/{id}/verify`.
+4. The user adds that token to `plate.yaml` in their repository and calls `POST /plates/{id}/verify`.
 5. On success the plate becomes `status=approved`, `visibility=public`, `is_verified=true`.
 
 ## Synchronizer
@@ -174,7 +174,7 @@ The sync worker runs as `app:sync`. It loops on `sync.poll_interval`, queries pl
 flowchart TD
     DUE[Query plates due for sync]
     SYNCING[Set sync_status = syncing]
-    FETCH[Fetch kikplate.yaml from GitHub]
+    FETCH[Fetch plate.yaml from GitHub]
     TOK{Token matches?}
     OK[Update metadata and tags  Set sync_status = synced]
     BAD[Set sync_status = unverified  Visibility = private]
@@ -215,7 +215,7 @@ PostgreSQL GIN indexes are created for full-text search and trigram matching. B-
 - Backend: Go, Chi, Uber Fx, GORM, PostgreSQL
 - Frontend: Next.js
 - Auth: local email/password, OAuth providers, or trusted header auth
-- Sync: background worker that re-fetches `kikplate.yaml` from GitHub
+- Sync: background worker that re-fetches `plate.yaml` from GitHub
 
 ```mermaid
 graph TD
@@ -327,12 +327,12 @@ Current routes are registered by `api/handler/routes/module.go`.
 Kickplate is repository-first. Plate type is currently only `repository`.
 
 1. User submits repository via `POST /plates/repository`.
-2. Service fetches `kikplate.yaml` from the submitted repo and branch.
+2. Service fetches `plate.yaml` from the submitted repo and branch.
 3. Owner validation:
-- Personal submission: `kikplate.yaml.owner` must match username.
-- Organization submission: `kikplate.yaml.owner` must match org name.
+- Personal submission: `plate.yaml.owner` must match username.
+- Organization submission: `plate.yaml.owner` must match org name.
 4. Plate is created as pending + private with generated `verification_token`.
-5. User adds that token to `kikplate.yaml` and calls `POST /plates/{id}/verify`.
+5. User adds that token to `plate.yaml` and calls `POST /plates/{id}/verify`.
 6. On success: plate becomes approved, public, verified, and sync schedule is initialized.
 
 ```mermaid
@@ -351,7 +351,7 @@ stateDiagram-v2
 For each due plate:
 
 1. Mark `sync_status=syncing`.
-2. Fetch `kikplate.yaml` from GitHub API.
+2. Fetch `plate.yaml` from GitHub API.
 3. Validate verification token still matches.
 4. If valid, update metadata + tags and mark synced.
 5. If invalid/missing token, mark unverified and force private visibility.
@@ -361,7 +361,7 @@ For each due plate:
 flowchart TD
 	DUE[List due plates]
 	SYNCING[Set sync_status=syncing]
-	FETCH[Fetch kikplate.yaml]
+	FETCH[Fetch plate.yaml]
 	TOK{Token matches?}
 	OK[Update metadata/tags\nSet synced]
 	BAD[Set unverified\nForce private]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -217,11 +217,11 @@ Example for an organization-scoped plate:
 kikplate submit https://github.com/myorg/my-template --org <org-uuid> --branch main
 ```
 
-After submission, the CLI prints the assigned slug and the `verification_token` you need to add to your `kikplate.yaml`.
+After submission, the CLI prints the assigned slug and the `verification_token` you need to add to your `plate.yaml`.
 
 ## Verifying a Plate
 
-After adding the verification token to `kikplate.yaml` and pushing the commit:
+After adding the verification token to `plate.yaml` and pushing the commit:
 
 ```
 kikplate verify myorg/my-template
@@ -231,7 +231,7 @@ On success the plate becomes approved, public, and verified. The CLI confirms th
 
 ## Scaffolding a Project
 
-Scaffolding creates a new project from a plate. The source repository is cloned, the `kikplate.yaml` manifest is stripped, and `.kikplate.origin` is written to record the provenance.
+Scaffolding creates a new project from a plate. The source repository is cloned, the `plate.yaml` manifest is stripped, and `.kikplate.origin` is written to record the provenance.
 
 ### Scaffold to a Local Directory
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -226,9 +226,9 @@ Supported `tier` values are `official` and `community`. Badge icons use the Luci
 
 ### plate_categories
 
-Defines the **allowed plate taxonomy**: which `category` values are valid in `kikplate.yaml`, how they appear in the web app (home “browse by category”, explore filters, stats), and how the API normalizes categories when ingesting manifests.
+Defines the **allowed plate taxonomy**: which `category` values are valid in `plate.yaml`, how they appear in the web app (home “browse by category”, explore filters, stats), and how the API normalizes categories when ingesting manifests.
 
-#### `category` in `kikplate.yaml`
+#### `category` in `plate.yaml`
 
 Repository authors set `category` to the **`slug`** of one entry in `plate_categories`. Matching is **case-insensitive** after trimming whitespace. If the field is omitted, empty, or not in the list, the stored category becomes the slug used for “other” (by default `other`). Submit and sync **do not fail** on a bad category value.
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -119,7 +119,7 @@ Key fields:
 - `consecutive_failures`
 
 - Metadata:
-- `metadata` jsonb (parsed `kikplate.yaml`)
+- `metadata` jsonb (parsed `plate.yaml`)
 
 - Timestamps:
 - `published_at` nullable
@@ -133,7 +133,7 @@ Notes:
 ```mermaid
 flowchart LR
 	SUBMIT[Submit repository]
-	YAML[Read kikplate.yaml]
+	YAML[Read plate.yaml]
 	PENDING[plate: pending/private\nverification_token set]
 	VERIFY[POST verify]
 	APPROVED[approved/public\nis_verified=true]

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -8,9 +8,9 @@ This document explains the core concepts of Kikplate and walks through the full 
 
 A plate is a project template backed by a public GitHub repository. It is the central entity in Kikplate. When a developer finds a plate they like, they can scaffold a new project from it in seconds using the CLI.
 
-Every plate must have a `kikplate.yaml` manifest at the root of its repository. That file is the contract between the repository author and the Kikplate platform.
+Every plate must have a `plate.yaml` manifest at the root of its repository. That file is the contract between the repository author and the Kikplate platform.
 
-### kikplate.yaml
+### plate.yaml
 
 The manifest describes the plate to the platform. A minimal example:
 
@@ -61,7 +61,7 @@ Badges are quality signals awarded to plates. They are defined in `config/config
 
 ### Organization
 
-Organizations are named namespaces that group plates under a shared identity. A user creates an organization, and other users can submit plates under that organization's name. The `kikplate.yaml` owner field must match the organization name for organization-scoped plates.
+Organizations are named namespaces that group plates under a shared identity. A user creates an organization, and other users can submit plates under that organization's name. The `plate.yaml` owner field must match the organization name for organization-scoped plates.
 
 ## Plate Lifecycle
 
@@ -85,7 +85,7 @@ kikplate submit https://github.com/myorg/my-template
 
 When a plate is submitted, Kikplate:
 
-1. Fetches `kikplate.yaml` from the specified repository and branch.
+1. Fetches `plate.yaml` from the specified repository and branch.
 2. Validates that the `owner` field matches the authenticated user's username (or organization name if submitted under an organization).
 3. Creates a plate record with `status=pending` and `visibility=private`.
 4. Generates a `verification_token` and stores it on the plate.
@@ -94,7 +94,7 @@ The verification token is returned in the submission response and printed by the
 
 ### Step 2: Verification
 
-The owner adds the `verification_token` to their `kikplate.yaml`, commits it, and then calls:
+The owner adds the `verification_token` to their `plate.yaml`, commits it, and then calls:
 
 ```
 POST /plates/{id}/verify
@@ -106,7 +106,7 @@ Or using the CLI:
 kikplate verify myorg/my-template
 ```
 
-Kikplate re-fetches `kikplate.yaml` and checks that the token in the file matches the one stored in the database. If they match, the plate transitions to `status=approved`, `visibility=public`, `is_verified=true`.
+Kikplate re-fetches `plate.yaml` and checks that the token in the file matches the one stored in the database. If they match, the plate transitions to `status=approved`, `visibility=public`, `is_verified=true`.
 
 The plate is now publicly discoverable and searchable.
 
@@ -116,7 +116,7 @@ After a plate is approved, the sync worker monitors the repository on a schedule
 
 For each due plate, the sync worker:
 
-1. Fetches `kikplate.yaml` from GitHub.
+1. Fetches `plate.yaml` from GitHub.
 2. Validates the verification token is still present and correct.
 3. If valid: updates the plate metadata and tags, sets `sync_status=synced`, and schedules the next sync.
 4. If the token is missing or wrong: sets `sync_status=unverified` and forces `visibility=private`. The plate is effectively taken offline until the owner verifies again.
@@ -173,7 +173,7 @@ The CLI:
 
 1. Looks up the plate in your local list or queries the server.
 2. Clones the repository into `my-new-project/`.
-3. Strips the `kikplate.yaml` manifest (it is the template author's file, not yours).
+3. Strips the `plate.yaml` manifest (it is the template author's file, not yours).
 4. Creates a `.kikplate.origin` file recording where the project came from.
 5. Optionally stamps the README with a "Scaffolded from" footer.
 

--- a/web/app/(auth)/set-username/page.tsx
+++ b/web/app/(auth)/set-username/page.tsx
@@ -64,7 +64,7 @@ export default function SetUsernamePage() {
           <p className="text-sm text-muted-foreground">
             Your username identifies you on KikPlate and is used as the{" "}
             <code className="font-mono bg-muted px-1 py-0.5 text-xs">owner</code>{" "}
-            field in <code className="font-mono bg-muted px-1 py-0.5 text-xs">kikplate.yaml</code>.
+            field in <code className="font-mono bg-muted px-1 py-0.5 text-xs">plate.yaml</code>.
           </p>
         </div>
 

--- a/web/src/presentation/components/plates/PendingVerification.tsx
+++ b/web/src/presentation/components/plates/PendingVerification.tsx
@@ -55,7 +55,7 @@ export function PendingVerification({ plate, onRemove, removing = false }: Props
             <div className="min-w-0">
               <p className="font-semibold text-amber-900 dark:text-amber-100">Verification Pending</p>
               <p className="mt-1 text-sm text-amber-800 dark:text-amber-200">
-                To publish this plate, add the verification token to your kikplate.yaml and push it to the repository.
+                To publish this plate, add the verification token to your plate.yaml and push it to the repository.
               </p>
             </div>
             {onRemove ? (
@@ -80,7 +80,7 @@ export function PendingVerification({ plate, onRemove, removing = false }: Props
           </div>
 
           <div className="space-y-2">
-            <p className="text-sm font-medium text-amber-900 dark:text-amber-100">Add this to your kikplate.yaml:</p>
+            <p className="text-sm font-medium text-amber-900 dark:text-amber-100">Add this to your plate.yaml:</p>
             <div className="flex gap-2">
               <code className="flex-1 overflow-auto rounded bg-amber-100/50 px-3 py-2 font-mono text-xs text-foreground dark:bg-amber-950/40">
                 {snippetYAML}

--- a/web/src/presentation/components/submit/SubmitRepositoryForm.tsx
+++ b/web/src/presentation/components/submit/SubmitRepositoryForm.tsx
@@ -25,8 +25,8 @@ export function SubmitRepositoryForm() {
   const isPersonalSubmission = !organizationId
   const ownerHint = selectedOrganization?.name ?? me?.username ?? "your-username"
   const [ownerCopied, setOwnerCopied] = useState(false)
-  const kikplateFileUrl = repoUrl
-    ? `${repoUrl.replace(/\.git$/, "").replace(/\/$/, "")}/blob/${branch || "main"}/kikplate.yaml`
+  const plateFileUrl = repoUrl
+    ? `${repoUrl.replace(/\.git$/, "").replace(/\/$/, "")}/blob/${branch || "main"}/plate.yaml`
     : null
 
   async function handleSubmit(e: React.FormEvent) {
@@ -57,7 +57,7 @@ export function SubmitRepositoryForm() {
           <div>
             <h2 className="text-sm font-semibold text-foreground">Before you submit</h2>
             <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
-              Add <code className="font-mono bg-muted px-1 py-0.5">kikplate.yaml</code> at the repository root.{" "}
+              Add <code className="font-mono bg-muted px-1 py-0.5">plate.yaml</code> at the repository root.{" "}
               <Link
                 href="/docs?doc=how-it-works"
                 className="font-medium text-foreground underline underline-offset-2 hover:text-muted-foreground"
@@ -74,7 +74,7 @@ export function SubmitRepositoryForm() {
             <ul className="list-disc pl-4 space-y-1 mb-3">
               <li>The repository must be public.</li>
               <li>
-                It must include <code className="font-mono bg-muted px-1 py-0.5">kikplate.yaml</code> at the root on
+                It must include <code className="font-mono bg-muted px-1 py-0.5">plate.yaml</code> at the root on
                 the branch you enter below.
               </li>
             </ul>
@@ -88,7 +88,7 @@ export function SubmitRepositoryForm() {
                 <p className="text-[11px] text-muted-foreground leading-relaxed">
                   Under Repository details, leave <span className="text-foreground font-medium">Personal</span>. The
                   plate is registered on <span className="text-foreground font-medium">your user account</span> only.
-                  In <code className="font-mono bg-muted px-1 py-0.5">kikplate.yaml</code>, set{" "}
+                  In <code className="font-mono bg-muted px-1 py-0.5">plate.yaml</code>, set{" "}
                   <code className="font-mono bg-muted px-1 py-0.5">owner</code> to your Kikplate username
                   {me?.username ? (
                     <> (<span className="font-mono text-foreground">{me.username}</span>)</>
@@ -102,7 +102,7 @@ export function SubmitRepositoryForm() {
                 <p className="text-[11px] text-muted-foreground leading-relaxed">
                   Under Repository details, choose an <span className="text-foreground font-medium">organization you own</span>.
                   The plate is registered <span className="text-foreground font-medium">under that organization</span> (not
-                  only on your user). In <code className="font-mono bg-muted px-1 py-0.5">kikplate.yaml</code>, set{" "}
+                  only on your user). In <code className="font-mono bg-muted px-1 py-0.5">plate.yaml</code>, set{" "}
                   <code className="font-mono bg-muted px-1 py-0.5">owner</code> to the{" "}
                   <span className="text-foreground font-medium">organization&apos;s exact name</span>—not your personal
                   username.
@@ -253,17 +253,17 @@ tags:
             <div className="pl-6 space-y-2 text-xs text-muted-foreground">
               <p>
                 Open{" "}
-                {kikplateFileUrl ? (
+                {plateFileUrl ? (
                   <a
-                    href={kikplateFileUrl}
+                    href={plateFileUrl}
                     target="_blank"
                     rel="noreferrer"
                     className="font-mono underline underline-offset-2 hover:text-foreground"
                   >
-                    kikplate.yaml
+                    plate.yaml
                   </a>
                 ) : (
-                  <code className="font-mono bg-muted px-1 py-0.5">kikplate.yaml</code>
+                  <code className="font-mono bg-muted px-1 py-0.5">plate.yaml</code>
                 )}{" "}
                 and update the <code className="font-mono bg-muted px-1 py-0.5">owner</code> field, then push and try again.
               </p>
@@ -296,14 +296,14 @@ tags:
           {(errorMsg.includes("not found") || errorMsg.includes("fetch")) && (
             <p className="text-xs text-muted-foreground pl-6">
               Make sure the repository is public, the URL is correct, and
-              the <code className="font-mono bg-muted px-1 py-0.5">kikplate.yaml</code> exists
+              the <code className="font-mono bg-muted px-1 py-0.5">plate.yaml</code> exists
               on the <code className="font-mono bg-muted px-1 py-0.5">{branch}</code> branch.
             </p>
           )}
           {errorMsg.includes("conflict") && (
             <p className="text-xs text-muted-foreground pl-6">
               A plate with this name already exists. Rename your plate in{" "}
-              <code className="font-mono bg-muted px-1 py-0.5">kikplate.yaml</code> and try again.
+              <code className="font-mono bg-muted px-1 py-0.5">plate.yaml</code> and try again.
             </p>
           )}
         </div>


### PR DESCRIPTION
## PR Summary

This PR unifies repository manifests by making `plate.yaml` the primary manifest for submission, verification, sync, generation guidance, and user-facing documentation, while preserving backward compatibility with `kikplate.yaml` during migration.

## Why

Maintaining two manifests created confusion for template authors and increased drift risk between metadata and generation configuration.

With this change, new templates can rely on one manifest, and existing templates continue to work safely.

## What Changed

### Backend
- Added `plate.yaml`-first manifest loading in submission and verification flows.
- Kept fallback support to `kikplate.yaml` for existing repositories.
- Updated sync worker to use the same `plate.yaml`-first fallback strategy.
- Updated manifest-related error messaging to reflect both supported files.

### CLI
- Updated `submit` and `verify` command messaging to instruct users to use `plate.yaml`.
- Updated scaffold cleanup behavior to strip both `plate.yaml` and `kikplate.yaml` from scaffolded output.

### Frontend
- Updated submit flow text and manifest links to point to `plate.yaml`.
- Updated pending verification instructions to reference `plate.yaml`.
- Updated username setup guidance to reference the `plate.yaml` owner field.

### Documentation
- Replaced `kikplate.yaml` and `kickplate.yaml` references with `plate.yaml` across docs and README files.
- Updated lifecycle and sync wording to reflect current manifest behavior.

## Compatibility

- New repositories: `plate.yaml` only works end-to-end.
- Existing repositories: `kikplate.yaml` still supported via fallback.
- No breaking migration required for current users.

## Validation

- API build passed.
- CLI build passed.
- Frontend text and link references were updated to match the new manifest convention.
- Markdown docs were scanned to ensure no remaining `kikplate.yaml` or `kickplate.yaml` references.

## Impact

This is a safe migration step toward a single-manifest model, with no disruption for existing template repositories.

closes #192 