### PR TITLE
feat(auth): add password reset flow with email delivery hardening and…

### DIFF
--- a/api/events/events.go
+++ b/api/events/events.go
@@ -4,6 +4,7 @@ const (
 	UserRegistered            = "user.registered"
 	UserVerificationRequested = "user.verification_requested"
 	PasswordChanged           = "user.password_changed"
+	PasswordResetRequested    = "user.password_reset_requested"
 	UserLiked                 = "user.liked"
 	PlateSubmitted            = "plate.submitted"
 	PlateVerified             = "plate.verified"
@@ -24,6 +25,12 @@ type UserVerificationRequestedPayload struct {
 
 type PasswordChangedPayload struct {
 	Email string
+}
+
+type PasswordResetRequestedPayload struct {
+	Email    string
+	Name     string
+	ResetURL string
 }
 
 type UserLikedPayload struct {

--- a/api/handler/handlers/auth_handler.go
+++ b/api/handler/handlers/auth_handler.go
@@ -362,3 +362,44 @@ func (h AuthHandler) Providers(w http.ResponseWriter, r *http.Request) {
 		"providers": names,
 	})
 }
+
+func (h AuthHandler) RequestPasswordReset(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Email string `json:"email"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if err := h.authService.RequestPasswordReset(r.Context(), input.Email); err != nil {
+		h.logger.Errorf("request password reset failed: %v", err)
+		respondServiceError(w, err)
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]string{
+		"message": "if an account exists with that email, you will receive a password reset link",
+	})
+}
+
+func (h AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Token       string `json:"token"`
+		NewPassword string `json:"new_password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if err := h.authService.ResetPassword(r.Context(), input.Token, input.NewPassword); err != nil {
+		h.logger.Errorf("reset password failed: %v", err)
+		respondServiceError(w, err)
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]string{
+		"message": "password reset successfully",
+	})
+}

--- a/api/handler/handlers/helpers.go
+++ b/api/handler/handlers/helpers.go
@@ -28,6 +28,8 @@ func respondServiceError(w http.ResponseWriter, err error) {
 		respondError(w, http.StatusConflict, err.Error())
 	case errors.Is(err, auth.ErrInvalidUsername):
 		respondError(w, http.StatusUnprocessableEntity, err.Error())
+	case errors.Is(err, auth.ErrWeakPassword):
+		respondError(w, http.StatusUnprocessableEntity, err.Error())
 	case errors.Is(err, auth.ErrInvalidPassword):
 		respondError(w, http.StatusUnauthorized, err.Error())
 	case errors.Is(err, auth.ErrAccountInactive):

--- a/api/handler/routes/auth_routes.go
+++ b/api/handler/routes/auth_routes.go
@@ -33,6 +33,8 @@ func (r AuthRoutes) Setup() {
 		router.Post("/register", r.handler.Register)
 		router.Get("/verify-email", r.handler.VerifyEmail)
 		router.Post("/login", r.handler.LoginLocal)
+		router.Post("/request-password-reset", r.handler.RequestPasswordReset)
+		router.Post("/reset-password", r.handler.ResetPassword)
 		router.Get("/{provider}/redirect", r.handler.OAuthRedirect)
 		router.Get("/{provider}/callback", r.handler.OAuthCallback)
 		router.Get("/providers", r.handler.Providers)

--- a/api/lib/db.go
+++ b/api/lib/db.go
@@ -161,6 +161,7 @@ func NewDatabase(env Env, logger Logger) Database {
 		&model.Account{},
 		&model.Organization{},
 		&model.EmailVerification{},
+		&model.PasswordReset{},
 		&model.Plate{},
 		&model.PlateTag{},
 		&model.PlateMember{},

--- a/api/model/password_reset.go
+++ b/api/model/password_reset.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type PasswordReset struct {
+	ID        uuid.UUID `gorm:"type:uuid;primaryKey"          json:"id"`
+	UserID    uuid.UUID `gorm:"type:uuid;not null;index"      json:"user_id"`
+	Token     string    `gorm:"size:255;not null;uniqueIndex" json:"-"`
+	IsUsed    bool      `gorm:"default:false"                 json:"is_used"`
+	ExpiresAt time.Time `gorm:"not null"                      json:"expires_at"`
+	CreatedAt time.Time `gorm:"autoCreateTime"                json:"created_at"`
+
+	User *User `gorm:"foreignKey:UserID" json:"-"`
+}
+
+func (PasswordReset) TableName() string {
+	return "password_reset"
+}

--- a/api/repository/postgres/module.go
+++ b/api/repository/postgres/module.go
@@ -6,6 +6,7 @@ var Module = fx.Options(
 	fx.Provide(NewUserRepository),
 	fx.Provide(NewAccountRepository),
 	fx.Provide(NewEmailVerificationRepository),
+	fx.Provide(NewPasswordResetRepository),
 	fx.Provide(NewPlateRepository),
 	fx.Provide(NewPlateTagRepository),
 	fx.Provide(NewPlateMemberRepository),

--- a/api/repository/postgres/password_reset.go
+++ b/api/repository/postgres/password_reset.go
@@ -1,0 +1,57 @@
+package postgres
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kickplate/api/lib"
+	"github.com/kickplate/api/model"
+	"github.com/kickplate/api/repository"
+	"gorm.io/gorm"
+)
+
+type passwordResetRepository struct {
+	db *gorm.DB
+}
+
+func NewPasswordResetRepository(db lib.Database) repository.PasswordResetRepository {
+	return &passwordResetRepository{db: db.DB}
+}
+
+func (r *passwordResetRepository) Create(ctx context.Context, pr *model.PasswordReset) error {
+	return r.db.WithContext(ctx).Create(pr).Error
+}
+
+func (r *passwordResetRepository) GetByToken(ctx context.Context, token string) (*model.PasswordReset, error) {
+	pr := &model.PasswordReset{}
+	result := r.db.WithContext(ctx).
+		Where("token = ? AND is_used = false AND expires_at > ?", token, time.Now()).
+		First(pr)
+	if result.Error == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	return pr, result.Error
+}
+
+func (r *passwordResetRepository) CountByUserSince(ctx context.Context, userID uuid.UUID, since time.Time) (int64, error) {
+	var count int64
+	err := r.db.WithContext(ctx).
+		Model(&model.PasswordReset{}).
+		Where("user_id = ? AND created_at >= ?", userID, since).
+		Count(&count).Error
+	return count, err
+}
+
+func (r *passwordResetRepository) MarkUsed(ctx context.Context, id uuid.UUID) error {
+	return r.db.WithContext(ctx).
+		Model(&model.PasswordReset{}).
+		Where("id = ?", id).
+		Update("is_used", true).Error
+}
+
+func (r *passwordResetRepository) DeleteExpired(ctx context.Context) error {
+	return r.db.WithContext(ctx).
+		Where("expires_at < ? OR is_used = true", time.Now()).
+		Delete(&model.PasswordReset{}).Error
+}

--- a/api/repository/repository.go
+++ b/api/repository/repository.go
@@ -108,6 +108,14 @@ type EmailVerificationRepository interface {
 	DeleteExpired(ctx context.Context) error
 }
 
+type PasswordResetRepository interface {
+	Create(ctx context.Context, pr *model.PasswordReset) error
+	GetByToken(ctx context.Context, token string) (*model.PasswordReset, error)
+	CountByUserSince(ctx context.Context, userID uuid.UUID, since time.Time) (int64, error)
+	MarkUsed(ctx context.Context, id uuid.UUID) error
+	DeleteExpired(ctx context.Context) error
+}
+
 type PlateRepository interface {
 	Create(ctx context.Context, plate *model.Plate) error
 	GetByID(ctx context.Context, id uuid.UUID) (*model.Plate, error)

--- a/api/service/auth/auth.go
+++ b/api/service/auth/auth.go
@@ -18,6 +18,8 @@ type AuthService interface {
 	DeleteMe(ctx context.Context, accountID uuid.UUID) error
 	SetUsername(ctx context.Context, accountID uuid.UUID, username string) error
 	UpdateProfile(ctx context.Context, accountID uuid.UUID, input UpdateProfileInput) (*MeResult, error)
+	RequestPasswordReset(ctx context.Context, email string) error
+	ResetPassword(ctx context.Context, token string, newPassword string) error
 }
 
 type UpdateProfileInput struct {

--- a/api/service/auth/auth_service.go
+++ b/api/service/auth/auth_service.go
@@ -22,32 +22,41 @@ import (
 )
 
 type authService struct {
-	userRepo     repository.UserRepository
-	accountRepo  repository.AccountRepository
-	emailVerRepo repository.EmailVerificationRepository
-	logger       lib.Logger
-	env          lib.Env
-	db           *gorm.DB
-	emitter      *events.EventEmitter
+	userRepo          repository.UserRepository
+	accountRepo       repository.AccountRepository
+	emailVerRepo      repository.EmailVerificationRepository
+	passwordResetRepo repository.PasswordResetRepository
+	logger            lib.Logger
+	env               lib.Env
+	db                *gorm.DB
+	emitter           *events.EventEmitter
 }
+
+const (
+	passwordResetCooldownInterval = time.Minute
+	passwordResetWindowInterval   = time.Hour
+	passwordResetWindowMax        = 5
+)
 
 func NewAuthService(
 	userRepo repository.UserRepository,
 	accountRepo repository.AccountRepository,
 	emailVerRepo repository.EmailVerificationRepository,
+	passwordResetRepo repository.PasswordResetRepository,
 	db lib.Database,
 	logger lib.Logger,
 	env lib.Env,
 	emitter *events.EventEmitter,
 ) AuthService {
 	return &authService{
-		userRepo:     userRepo,
-		accountRepo:  accountRepo,
-		emailVerRepo: emailVerRepo,
-		logger:       logger,
-		env:          env,
-		db:           db.DB,
-		emitter:      emitter,
+		userRepo:          userRepo,
+		accountRepo:       accountRepo,
+		emailVerRepo:      emailVerRepo,
+		passwordResetRepo: passwordResetRepo,
+		logger:            logger,
+		env:               env,
+		db:                db.DB,
+		emitter:           emitter,
 	}
 }
 
@@ -719,6 +728,9 @@ func (s *authService) DeleteMe(ctx context.Context, accountID uuid.UUID) error {
 				if err := tx.Where("user_id = ?", *account.UserID).Delete(&model.EmailVerification{}).Error; err != nil {
 					return err
 				}
+				if err := tx.Where("user_id = ?", *account.UserID).Delete(&model.PasswordReset{}).Error; err != nil {
+					return err
+				}
 				if err := tx.Where("id = ?", *account.UserID).Delete(&model.User{}).Error; err != nil {
 					return err
 				}
@@ -727,4 +739,142 @@ func (s *authService) DeleteMe(ctx context.Context, accountID uuid.UUID) error {
 
 		return nil
 	})
+}
+
+func (s *authService) RequestPasswordReset(ctx context.Context, email string) error {
+	email = strings.ToLower(strings.TrimSpace(email))
+	if email == "" {
+		return nil
+	}
+
+	user, err := s.userRepo.GetByEmail(ctx, email)
+	if err != nil {
+		return err
+	}
+	if user == nil {
+		return nil
+	}
+
+	cooldownCount, err := s.passwordResetRepo.CountByUserSince(ctx, user.ID, time.Now().Add(-passwordResetCooldownInterval))
+	if err != nil {
+		return err
+	}
+	if cooldownCount > 0 {
+		return nil
+	}
+
+	windowCount, err := s.passwordResetRepo.CountByUserSince(ctx, user.ID, time.Now().Add(-passwordResetWindowInterval))
+	if err != nil {
+		return err
+	}
+	if windowCount >= passwordResetWindowMax {
+		return nil
+	}
+
+	if !s.env.SMTP.IsConfigured() {
+		return ErrSMTPNotConfigured
+	}
+
+	ttl := 24 * time.Hour
+	if s.env.EmailVerification.TokenTTL != "" {
+		parsed, err := time.ParseDuration(s.env.EmailVerification.TokenTTL)
+		if err == nil && parsed > 0 {
+			ttl = parsed
+		}
+	}
+
+	rawToken := uuid.New().String()
+	hashed := fmt.Sprintf("%x", sha256.Sum256([]byte(rawToken)))
+
+	pr := &model.PasswordReset{
+		ID:        uuid.New(),
+		UserID:    user.ID,
+		Token:     hashed,
+		IsUsed:    false,
+		ExpiresAt: time.Now().Add(ttl),
+	}
+	if err := s.passwordResetRepo.Create(ctx, pr); err != nil {
+		return err
+	}
+
+	resetURL, err := s.buildPasswordResetURL(rawToken)
+	if err != nil {
+		return err
+	}
+
+	s.emitter.Emit(events.PasswordResetRequested, events.PasswordResetRequestedPayload{
+		Email:    user.Email,
+		Name:     user.Username,
+		ResetURL: resetURL,
+	})
+
+	return nil
+}
+
+func (s *authService) ResetPassword(ctx context.Context, token string, newPassword string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ErrTokenInvalid
+	}
+
+	if len(newPassword) < 8 {
+		return ErrWeakPassword
+	}
+
+	hashed := fmt.Sprintf("%x", sha256.Sum256([]byte(token)))
+
+	pr, err := s.passwordResetRepo.GetByToken(ctx, hashed)
+	if err != nil {
+		return err
+	}
+	if pr == nil {
+		return ErrTokenInvalid
+	}
+
+	user, err := s.userRepo.GetByID(ctx, pr.UserID)
+	if err != nil {
+		return err
+	}
+	if user == nil {
+		return ErrNotFound
+	}
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	if err != nil {
+		return err
+	}
+
+	user.PasswordHash = string(passwordHash)
+	if err := s.userRepo.Update(ctx, user); err != nil {
+		return err
+	}
+
+	if err := s.passwordResetRepo.MarkUsed(ctx, pr.ID); err != nil {
+		return err
+	}
+
+	s.emitter.Emit(events.PasswordChanged, events.PasswordChangedPayload{
+		Email: user.Email,
+	})
+
+	return nil
+}
+
+func (s *authService) buildPasswordResetURL(rawToken string) (string, error) {
+	base := strings.TrimSpace(s.env.FrontendURL)
+	if base == "" {
+		base = "http://localhost:3000"
+	}
+	base = strings.TrimRight(base, "/") + "/reset-password"
+
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+
+	query := parsed.Query()
+	query.Set("token", rawToken)
+	parsed.RawQuery = query.Encode()
+
+	return parsed.String(), nil
 }

--- a/api/service/auth/errors.go
+++ b/api/service/auth/errors.go
@@ -15,4 +15,5 @@ var (
 	ErrProviderNotFound        = errors.New("oauth provider not configured")
 	ErrOAuthFailed             = errors.New("oauth authentication failed")
 	ErrInvalidUsername         = errors.New("username cannot be empty")
+	ErrWeakPassword            = errors.New("password must be at least 8 characters")
 )

--- a/api/service/email/listener.go
+++ b/api/service/email/listener.go
@@ -26,6 +26,11 @@ func (l *Listener) Register(emitter *events.EventEmitter) {
 		l.emailService.SendPasswordChanged(p.Email)
 	})
 
+	emitter.On(events.PasswordResetRequested, func(payload any) {
+		p := payload.(events.PasswordResetRequestedPayload)
+		l.emailService.SendPasswordResetEmail(p.Email, p.Name, p.ResetURL)
+	})
+
 	emitter.On(events.UserLiked, func(payload any) {
 		p := payload.(events.UserLikedPayload)
 		l.emailService.SendLikeNotification(p.Email, p.LikedBy)

--- a/api/service/email/service.go
+++ b/api/service/email/service.go
@@ -50,6 +50,13 @@ func (s *Service) SendPasswordChanged(to string) error {
 	return s.send(to, "Your password was changed", renderTemplate("password_change.html", s.templateData(nil)))
 }
 
+func (s *Service) SendPasswordResetEmail(to, name, resetURL string) error {
+	return s.send(to, "Reset your Kikplate password", renderTemplate("password_reset.html", s.templateData(map[string]any{
+		"Name":     name,
+		"ResetURL": resetURL,
+	})))
+}
+
 func (s *Service) SendLikeNotification(to, likedBy string) error {
 	return s.send(to, "Someone liked you!", renderTemplate("like_notification.html", s.templateData(map[string]any{
 		"LikedBy": likedBy,

--- a/api/service/email/templates/password_reset.html
+++ b/api/service/email/templates/password_reset.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Reset your Kikplate password</title>
+</head>
+<body style="margin:0;padding:0;background:#f7fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#1a202c;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="padding:24px 0;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;background:#ffffff;border:1px solid #e2e8f0;border-radius:12px;overflow:hidden;">
+          <tr>
+            <td style="padding:22px 28px 0 28px;">
+              <div style="display:inline-flex;align-items:center;">
+                <img src="{{ .LogoURL }}" alt="Kikplate" width="140" style="display:block;height:auto;border:0;outline:none;text-decoration:none;" />
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:28px 28px 14px 28px;background:#0f172a;color:#f8fafc;">
+              <h1 style="margin:0;font-size:22px;line-height:1.3;">Reset your password</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 28px;">
+              <p style="margin:0 0 12px 0;font-size:16px;line-height:1.6;">Hi {{ .Name }},</p>
+              <p style="margin:0 0 18px 0;font-size:15px;line-height:1.6;">We received a request to reset your Kikplate password. Click the link below to create a new password.</p>
+              <p style="margin:0 0 18px 0;">
+                <a href="{{ .ResetURL }}" style="display:inline-block;background:#0f172a;color:#ffffff;text-decoration:none;padding:10px 16px;border-radius:8px;font-size:14px;">Reset Password</a>
+              </p>
+              <p style="margin:0 0 20px 0;font-size:13px;line-height:1.5;color:#475569;word-break:break-all;">If the button does not work, open this link: {{ .ResetURL }}</p>
+              <p style="margin:0 0 18px 0;font-size:13px;line-height:1.5;color:#64748b;">This link expires in 24 hours for security reasons.</p>
+              <hr style="border:none;border-top:1px solid #e2e8f0;margin:0 0 14px 0;" />
+              <p style="margin:0;font-size:14px;line-height:1.7;color:#334155;">Warm regards,<br /><strong>The Kikplate Team</strong></p>
+              <p style="margin:8px 0 0 0;font-size:12px;line-height:1.6;color:#64748b;">Discover, share, and ship better templates.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/config/examples/config.yaml.example
+++ b/config/examples/config.yaml.example
@@ -73,7 +73,7 @@ customization:
   # Logo URL used in the navbar.
   # Local example: a file from web/public.
   # Kubernetes example: a CDN/object-storage URL managed via ConfigMap.
-  logo: "/kikplate-logo-on-dark.svg"
+  logo: "https://kikplate.dev/kikplate-logo-on-dark.svg"
 
   # Main hero title on the landing page.
   # Use \n to force a line break.

--- a/web/app/(auth)/forgot-password/page.tsx
+++ b/web/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,13 @@
+import { ForgotPasswordForm } from "@/src/presentation/components/auth/ForgotPasswordForm"
+
+export default function ForgotPasswordPage() {
+  return (
+    <div className="container mx-auto flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-sm border border-border bg-card p-6">
+        <h1 className="mb-3 text-2xl font-bold">Forgot password</h1>
+        <p className="mb-6 text-sm text-muted-foreground">Enter your email and we will send a reset link.</p>
+        <ForgotPasswordForm />
+      </div>
+    </div>
+  )
+}

--- a/web/app/(auth)/reset-password/page.tsx
+++ b/web/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from "react"
+import { ResetPasswordForm } from "@/src/presentation/components/auth/ResetPasswordForm"
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="container mx-auto flex min-h-screen items-center justify-center px-4">
+          <div className="w-full max-w-sm border border-border bg-card p-6">
+            <h1 className="mb-3 text-2xl font-bold">Reset password</h1>
+            <p className="mb-6 text-sm text-muted-foreground">Loading...</p>
+          </div>
+        </div>
+      }
+    >
+      <div className="container mx-auto flex min-h-screen items-center justify-center px-4">
+        <div className="w-full max-w-sm border border-border bg-card p-6">
+          <h1 className="mb-3 text-2xl font-bold">Reset password</h1>
+          <p className="mb-6 text-sm text-muted-foreground">Set a new password for your account.</p>
+          <ResetPasswordForm />
+        </div>
+      </div>
+    </Suspense>
+  )
+}

--- a/web/src/data/repositories/AuthRepository.ts
+++ b/web/src/data/repositories/AuthRepository.ts
@@ -25,6 +25,12 @@ class AuthRepository implements IAuthRepository {
   setUsername(username: string): Promise<{ message: string }> {
     return http.patch("/me/username", { username })
   }
+  requestPasswordReset(email: string): Promise<{ message: string }> {
+    return http.post("/auth/request-password-reset", { email })
+  }
+  resetPassword(token: string, newPassword: string): Promise<{ message: string }> {
+    return http.post("/auth/reset-password", { token, new_password: newPassword })
+  }
   oauthRedirectURL(provider: string): string {
     return `${CLIENT_API_BASE}/auth/${provider}/redirect`
   }

--- a/web/src/domain/repositories/IAuthRepository.ts
+++ b/web/src/domain/repositories/IAuthRepository.ts
@@ -4,6 +4,8 @@ export interface IAuthRepository {
   register(input: RegisterInput): Promise<{ message: string }>
   login(input: LoginInput): Promise<AuthResult>
   verifyEmail(token: string): Promise<AuthResult>
+  requestPasswordReset(email: string): Promise<{ message: string }>
+  resetPassword(token: string, newPassword: string): Promise<{ message: string }>
   me(): Promise<MeResult>
   deleteMe(): Promise<void>
   updateProfile(input: { display_name?: string; avatar_url?: string }): Promise<MeResult>

--- a/web/src/presentation/components/auth/ForgotPasswordForm.tsx
+++ b/web/src/presentation/components/auth/ForgotPasswordForm.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useRequestPasswordReset } from "@/src/presentation/hooks/useAuth"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { toast } from "sonner"
+import { Loader2 } from "lucide-react"
+
+export function ForgotPasswordForm() {
+  const router = useRouter()
+  const requestReset = useRequestPasswordReset()
+  const [email, setEmail] = useState("")
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    try {
+      const result = await requestReset.mutateAsync(email.trim().toLowerCase())
+      toast.success(result.message)
+      router.push("/login")
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : "Unable to request password reset")
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="email">Email</Label>
+        <Input
+          id="email"
+          type="email"
+          placeholder="you@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoComplete="email"
+        />
+      </div>
+
+      <Button type="submit" className="w-full" disabled={requestReset.isPending}>
+        {requestReset.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+        Send reset link
+      </Button>
+
+      <p className="text-center text-sm text-muted-foreground">
+        Remembered your password?{" "}
+        <Link href="/login" className="text-foreground underline underline-offset-4 hover:text-primary">
+          Sign in
+        </Link>
+      </p>
+    </form>
+  )
+}

--- a/web/src/presentation/components/auth/LoginForm.tsx
+++ b/web/src/presentation/components/auth/LoginForm.tsx
@@ -69,6 +69,11 @@ export function LoginForm() {
             required
             autoComplete="current-password"
           />
+          <div className="text-right">
+            <Link href="/forgot-password" className="text-sm text-foreground underline underline-offset-4 hover:text-primary">
+              Forgot password?
+            </Link>
+          </div>
         </div>
         <Button type="submit" className="w-full" disabled={login.isPending}>
           {login.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/web/src/presentation/components/auth/ResetPasswordForm.tsx
+++ b/web/src/presentation/components/auth/ResetPasswordForm.tsx
@@ -1,0 +1,88 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import Link from "next/link"
+import { useRouter, useSearchParams } from "next/navigation"
+import { useResetPassword } from "@/src/presentation/hooks/useAuth"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { toast } from "sonner"
+import { Loader2 } from "lucide-react"
+
+export function ResetPasswordForm() {
+  const router = useRouter()
+  const params = useSearchParams()
+  const resetPassword = useResetPassword()
+  const token = useMemo(() => params.get("token")?.trim() ?? "", [params])
+  const [newPassword, setNewPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+
+  const passwordsMatch = newPassword === confirmPassword
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+
+    if (!token) {
+      toast.error("Password reset token is missing")
+      return
+    }
+
+    if (!passwordsMatch) {
+      toast.error("Password confirmation does not match")
+      return
+    }
+
+    try {
+      const result = await resetPassword.mutateAsync({ token, newPassword })
+      toast.success(result.message)
+      router.push("/login")
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : "Unable to reset password")
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="new-password">New password</Label>
+        <Input
+          id="new-password"
+          type="password"
+          placeholder="••••••••"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          required
+          autoComplete="new-password"
+          minLength={8}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="confirm-password">Confirm new password</Label>
+        <Input
+          id="confirm-password"
+          type="password"
+          placeholder="••••••••"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          required
+          autoComplete="new-password"
+          minLength={8}
+        />
+      </div>
+
+      <Button type="submit" className="w-full" disabled={resetPassword.isPending || !passwordsMatch}>
+        {resetPassword.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+        Reset password
+      </Button>
+
+      <p className="text-center text-sm text-muted-foreground">
+        Back to{" "}
+        <Link href="/login" className="text-foreground underline underline-offset-4 hover:text-primary">
+          Sign in
+        </Link>
+      </p>
+    </form>
+  )
+}

--- a/web/src/presentation/hooks/useAuth.ts
+++ b/web/src/presentation/hooks/useAuth.ts
@@ -105,3 +105,16 @@ export function useProviders() {
     staleTime: Infinity,
   })
 }
+
+export function useRequestPasswordReset() {
+  return useMutation({
+    mutationFn: (email: string) => authRepository.requestPasswordReset(email),
+  })
+}
+
+export function useResetPassword() {
+  return useMutation({
+    mutationFn: ({ token, newPassword }: { token: string; newPassword: string }) =>
+      authRepository.resetPassword(token, newPassword),
+  })
+}


### PR DESCRIPTION
Added password recovery end-to-end across API and web, including new password reset model/repository, DB migration registration, auth service methods to request/reset password, and new auth routes/handlers for reset requests and token-based password updates. Added server-side throttling on password reset requests to reduce abuse and mapped weak-password validation errors. Extended event/email flow with a password-reset event and new reset email template plus sender wiring. Added frontend forgot-password and reset-password pages/forms, updated login with a forgot-password entry point, and wired repository contracts/hooks for the new API calls. Updated example configuration to use a public logo URL for better email logo rendering compatibility.